### PR TITLE
`Render` trait

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -25,45 +25,18 @@ use crate::Container;
 use crate::Event;
 use crate::ListKind;
 use crate::OrderedListNumbering::*;
+use crate::Render;
 
-/// Generate HTML and push it to a unicode-accepting buffer or stream.
-pub fn push<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write>(events: I, out: W) {
-    Writer::new(events, out).write().unwrap();
-}
+pub struct Renderer;
 
-/// Generate HTML and write it to a byte sink, encoded as UTF-8.
-///
-/// NOTE: This performs many small writes, so IO writes should be buffered with e.g.
-/// [`std::io::BufWriter`].
-pub fn write<'s, I: Iterator<Item = Event<'s>>, W: std::io::Write>(
-    events: I,
-    mut out: W,
-) -> std::io::Result<()> {
-    struct Adapter<'a, T: ?Sized + 'a> {
-        inner: &'a mut T,
-        error: std::io::Result<()>,
+impl Render for Renderer {
+    fn push<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write>(
+        &self,
+        events: I,
+        out: W,
+    ) -> std::fmt::Result {
+        Writer::new(events, out).write()
     }
-
-    impl<T: std::io::Write + ?Sized> std::fmt::Write for Adapter<'_, T> {
-        fn write_str(&mut self, s: &str) -> std::fmt::Result {
-            match self.inner.write_all(s.as_bytes()) {
-                Ok(()) => Ok(()),
-                Err(e) => {
-                    self.error = Err(e);
-                    Err(std::fmt::Error)
-                }
-            }
-        }
-    }
-
-    let mut output = Adapter {
-        inner: &mut out,
-        error: Ok(()),
-    };
-
-    Writer::new(events, &mut output)
-        .write()
-        .map_err(|_| output.error.unwrap_err())
 }
 
 enum Raw {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,10 @@
 //! # }
 //! ```
 
-use std::fmt::Write;
+use fmt::Write as FmtWrite;
+use io::Write as IoWrite;
+use std::fmt;
+use std::io;
 
 #[cfg(feature = "html")]
 pub mod html;
@@ -62,6 +65,55 @@ use span::Span;
 pub use attr::Attributes;
 
 type CowStr<'s> = std::borrow::Cow<'s, str>;
+
+pub trait Render {
+    /// Push [`Event`]s to a unicode-accepting buffer or stream.
+    fn push<'s, I: Iterator<Item = Event<'s>>, W: FmtWrite>(
+        &self,
+        events: I,
+        out: W,
+    ) -> fmt::Result;
+
+    /// Write [`Event`]s to a byte sink, encoded as UTF-8.
+    ///
+    /// NOTE: This performs many small writes, so IO writes should be buffered with e.g.
+    /// [`std::io::BufWriter`].
+    fn write<'s, I: Iterator<Item = Event<'s>>, W: IoWrite>(
+        &self,
+        events: I,
+        out: W,
+    ) -> io::Result<()> {
+        struct Adapter<T: IoWrite> {
+            inner: T,
+            error: io::Result<()>,
+        }
+
+        impl<T: IoWrite> fmt::Write for Adapter<T> {
+            fn write_str(&mut self, s: &str) -> fmt::Result {
+                match self.inner.write_all(s.as_bytes()) {
+                    Ok(()) => Ok(()),
+                    Err(e) => {
+                        self.error = Err(e);
+                        Err(fmt::Error)
+                    }
+                }
+            }
+        }
+
+        let mut out = Adapter {
+            inner: out,
+            error: Ok(()),
+        };
+
+        match self.push(events, &mut out) {
+            Ok(()) => Ok(()),
+            Err(_) => match out.error {
+                Err(_) => out.error,
+                _ => Err(io::Error::new(io::ErrorKind::Other, "formatter error")),
+            },
+        }
+    }
+}
 
 /// A Djot event.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use jotdown::Render;
 use std::io::Read;
 
 fn main() {
@@ -8,5 +9,6 @@ fn main() {
 
     let events = jotdown::Parser::new(&src);
     let mut out = std::io::BufWriter::new(std::io::stdout());
-    jotdown::html::write(events, &mut out).unwrap();
+    let html = jotdown::html::Renderer;
+    html.write(events, &mut out).unwrap();
 }


### PR DESCRIPTION
This adds the trait proposed in #10 and implements the HTML renderer.

The changes are reflected in `main.rs` as well, which means this PR will conflict with #8. We can probably just fix this when merging, so shouldn't be an issue.