### PR TITLE
Support escapes in attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ mod tree;
 use span::DiscontinuousString;
 use span::Span;
 
-pub use attr::Attributes;
+pub use attr::{AttributeValue, AttributeValueParts, Attributes};
 
 type CowStr<'s> = std::borrow::Cow<'s, str>;
 

--- a/tests/suite/skip
+++ b/tests/suite/skip
@@ -1,7 +1,5 @@
 38d85f9:multi-line block attributes
 6c14561:multi-line block attributes
-48546bb:escape in attributes
-6bc4257:escape in attributes
 613a9d6:attribute container precedence
 f4f22fc:attribute key class order
 ae6fc15:bugged left/right quote


### PR DESCRIPTION
This replaces the `CowStr` in `Attributes` with a new struct: `Attr`. This struct implements `Display`, which skips over what needs to be skipped and writes everything else.

~~If we want to keep the raw attributes as string slices, we cannot continue storing multiple classes as a space-separated string, but rather as a vec of string slices. This is also better when it comes to other output formats, as space-separated classes could be considered an HTML-ism. Seeing as classes really are a different type of attribute than all others, I am a bit unsure how we should do this. I toyed around with making `Attr` an enum (variants being `Class(Vec<&str>)` and `Other(&str)`,) but the nesting made this a nightmare. @hellux I would love your input on this!~~

~~Additionally, I have not yet made the `escape_backslash` test pass yet, but I have some ideas on how to get that going. Shouldn't be that difficult.~~