### PR TITLE
Allow rendering borrowed events

### DIFF
--- a/bench/criterion/main.rs
+++ b/bench/criterion/main.rs
@@ -64,6 +64,60 @@ fn gen_html(c: &mut criterion::Criterion) {
 }
 criterion_group!(html, gen_html);
 
+fn gen_html_borrow(c: &mut criterion::Criterion) {
+    let mut group = c.benchmark_group("html_borrow");
+    for (name, input) in bench_input::INPUTS {
+        group.throughput(criterion::Throughput::Elements(
+            jotdown::Parser::new(input).count() as u64,
+        ));
+        group.bench_with_input(
+            criterion::BenchmarkId::from_parameter(name),
+            input,
+            |b, &input| {
+                b.iter_batched(
+                    || jotdown::Parser::new(input).collect::<Vec<_>>(),
+                    |p| {
+                        let mut s = String::new();
+                        jotdown::html::Renderer::default()
+                            .push_borrowed(p.as_slice().iter(), &mut s)
+                            .unwrap();
+                        s
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+}
+criterion_group!(html_borrow, gen_html_borrow);
+
+fn gen_html_clone(c: &mut criterion::Criterion) {
+    let mut group = c.benchmark_group("html_clone");
+    for (name, input) in bench_input::INPUTS {
+        group.throughput(criterion::Throughput::Elements(
+            jotdown::Parser::new(input).count() as u64,
+        ));
+        group.bench_with_input(
+            criterion::BenchmarkId::from_parameter(name),
+            input,
+            |b, &input| {
+                b.iter_batched(
+                    || jotdown::Parser::new(input).collect::<Vec<_>>(),
+                    |p| {
+                        let mut s = String::new();
+                        jotdown::html::Renderer::default()
+                            .push(p.iter().cloned(), &mut s)
+                            .unwrap();
+                        s
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+}
+criterion_group!(html_clone, gen_html_clone);
+
 fn gen_full(c: &mut criterion::Criterion) {
     let mut group = c.benchmark_group("full");
     for (name, input) in bench_input::INPUTS {
@@ -85,4 +139,4 @@ fn gen_full(c: &mut criterion::Criterion) {
 }
 criterion_group!(full, gen_full);
 
-criterion_main!(block, inline, html, full);
+criterion_main!(block, inline, html, html_borrow, html_clone, full);

--- a/bench/criterion/main.rs
+++ b/bench/criterion/main.rs
@@ -51,7 +51,9 @@ fn gen_html(c: &mut criterion::Criterion) {
                     || jotdown::Parser::new(input).collect::<Vec<_>>(),
                     |p| {
                         let mut s = String::new();
-                        jotdown::html::Renderer.push(p.into_iter(), &mut s).unwrap();
+                        jotdown::html::Renderer::default()
+                            .push(p.into_iter(), &mut s)
+                            .unwrap();
                         s
                     },
                     criterion::BatchSize::SmallInput,
@@ -72,7 +74,7 @@ fn gen_full(c: &mut criterion::Criterion) {
             |b, &input| {
                 b.iter_with_large_drop(|| {
                     let mut s = String::new();
-                    jotdown::html::Renderer
+                    jotdown::html::Renderer::default()
                         .push(jotdown::Parser::new(input), &mut s)
                         .unwrap();
                     s

--- a/bench/iai/main.rs
+++ b/bench/iai/main.rs
@@ -12,7 +12,7 @@ fn block_inline() -> Option<jotdown::Event<'static>> {
 
 fn full() -> String {
     let mut s = String::new();
-    jotdown::html::Renderer
+    jotdown::html::Renderer::default()
         .push(jotdown::Parser::new(bench_input::ALL), &mut s)
         .unwrap();
     s

--- a/examples/jotdown_wasm/src/lib.rs
+++ b/examples/jotdown_wasm/src/lib.rs
@@ -7,6 +7,8 @@ use jotdown::Render;
 pub fn jotdown_render(djot: &str) -> String {
     let events = jotdown::Parser::new(djot);
     let mut html = String::new();
-    jotdown::html::Renderer.push(events, &mut html).unwrap();
+    jotdown::html::Renderer::default()
+        .push(events, &mut html)
+        .unwrap();
     html
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -74,363 +74,378 @@ impl Default for Writer {
 }
 
 impl Writer {
-    fn write<'s>(
-        &mut self,
-        events: impl Iterator<Item = Event<'s>>,
-        mut out: impl std::fmt::Write,
-    ) -> std::fmt::Result {
-        for e in events {
-            if matches!(&e, Event::Blankline | Event::Escape) {
-                continue;
-            }
+    fn write<'s, I, W>(&mut self, mut events: I, mut out: W) -> std::fmt::Result
+    where
+        I: Iterator<Item = Event<'s>>,
+        W: std::fmt::Write,
+    {
+        events.try_for_each(|e| self.render_event(&e, &mut out))?;
+        self.render_epilogue(&mut out)
+    }
 
-            let close_para = self.close_para;
-            if close_para {
-                self.close_para = false;
-                if !matches!(&e, Event::End(Container::Footnote { .. })) {
-                    // no need to add href before para close
-                    out.write_str("</p>")?;
+    fn render_event<'s, W>(&mut self, e: &Event<'s>, mut out: W) -> std::fmt::Result
+    where
+        W: std::fmt::Write,
+    {
+        if matches!(&e, Event::Blankline | Event::Escape) {
+            return Ok(());
+        }
+
+        let close_para = self.close_para;
+        if close_para {
+            self.close_para = false;
+            if !matches!(&e, Event::End(Container::Footnote { .. })) {
+                // no need to add href before para close
+                out.write_str("</p>")?;
+            }
+        }
+
+        match e {
+            Event::Start(c, attrs) => {
+                if c.is_block() && !self.first_line {
+                    out.write_char('\n')?;
                 }
-            }
-
-            match e {
-                Event::Start(c, attrs) => {
-                    if c.is_block() && !self.first_line {
-                        out.write_char('\n')?;
-                    }
-                    if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
-                        continue;
-                    }
-                    match &c {
-                        Container::Blockquote => out.write_str("<blockquote")?,
-                        Container::List { kind, tight } => {
-                            self.list_tightness.push(*tight);
-                            match kind {
-                                ListKind::Unordered | ListKind::Task => out.write_str("<ul")?,
-                                ListKind::Ordered {
-                                    numbering, start, ..
-                                } => {
-                                    out.write_str("<ol")?;
-                                    if *start > 1 {
-                                        write!(out, r#" start="{}""#, start)?;
-                                    }
-                                    if let Some(ty) = match numbering {
-                                        Decimal => None,
-                                        AlphaLower => Some('a'),
-                                        AlphaUpper => Some('A'),
-                                        RomanLower => Some('i'),
-                                        RomanUpper => Some('I'),
-                                    } {
-                                        write!(out, r#" type="{}""#, ty)?;
-                                    }
+                if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
+                    return Ok(());
+                }
+                match &c {
+                    Container::Blockquote => out.write_str("<blockquote")?,
+                    Container::List { kind, tight } => {
+                        self.list_tightness.push(*tight);
+                        match kind {
+                            ListKind::Unordered | ListKind::Task => out.write_str("<ul")?,
+                            ListKind::Ordered {
+                                numbering, start, ..
+                            } => {
+                                out.write_str("<ol")?;
+                                if *start > 1 {
+                                    write!(out, r#" start="{}""#, start)?;
+                                }
+                                if let Some(ty) = match numbering {
+                                    Decimal => None,
+                                    AlphaLower => Some('a'),
+                                    AlphaUpper => Some('A'),
+                                    RomanLower => Some('i'),
+                                    RomanUpper => Some('I'),
+                                } {
+                                    write!(out, r#" type="{}""#, ty)?;
                                 }
                             }
                         }
-                        Container::ListItem | Container::TaskListItem { .. } => {
-                            out.write_str("<li")?;
-                        }
-                        Container::DescriptionList => out.write_str("<dl")?,
-                        Container::DescriptionDetails => out.write_str("<dd")?,
-                        Container::Footnote { number, .. } => {
-                            assert!(self.footnote_number.is_none());
-                            self.footnote_number = Some((*number).try_into().unwrap());
-                            if !self.encountered_footnote {
-                                self.encountered_footnote = true;
-                                out.write_str("<section role=\"doc-endnotes\">\n<hr>\n<ol>\n")?;
-                            }
-                            write!(out, "<li id=\"fn{}\">", number)?;
-                            continue;
-                        }
-                        Container::Table => out.write_str("<table")?,
-                        Container::TableRow { .. } => out.write_str("<tr")?,
-                        Container::Section { .. } => out.write_str("<section")?,
-                        Container::Div { .. } => out.write_str("<div")?,
-                        Container::Paragraph => {
-                            if matches!(self.list_tightness.last(), Some(true)) {
-                                continue;
-                            }
-                            out.write_str("<p")?;
-                        }
-                        Container::Heading { level, .. } => write!(out, "<h{}", level)?,
-                        Container::TableCell { head: false, .. } => out.write_str("<td")?,
-                        Container::TableCell { head: true, .. } => out.write_str("<th")?,
-                        Container::Caption => out.write_str("<caption")?,
-                        Container::DescriptionTerm => out.write_str("<dt")?,
-                        Container::CodeBlock { .. } => out.write_str("<pre")?,
-                        Container::Span | Container::Math { .. } => out.write_str("<span")?,
-                        Container::Link(dst, ty) => {
-                            if matches!(ty, LinkType::Span(SpanLinkType::Unresolved)) {
-                                out.write_str("<a")?;
-                            } else {
-                                out.write_str(r#"<a href=""#)?;
-                                if matches!(ty, LinkType::Email) {
-                                    out.write_str("mailto:")?;
-                                }
-                                write_attr(dst, &mut out)?;
-                                out.write_char('"')?;
-                            }
-                        }
-                        Container::Image(..) => {
-                            self.img_alt_text += 1;
-                            if self.img_alt_text == 1 {
-                                out.write_str("<img")?;
-                            } else {
-                                continue;
-                            }
-                        }
-                        Container::Verbatim => out.write_str("<code")?,
-                        Container::RawBlock { format } | Container::RawInline { format } => {
-                            self.raw = if format == &"html" {
-                                Raw::Html
-                            } else {
-                                Raw::Other
-                            };
-                            continue;
-                        }
-                        Container::Subscript => out.write_str("<sub")?,
-                        Container::Superscript => out.write_str("<sup")?,
-                        Container::Insert => out.write_str("<ins")?,
-                        Container::Delete => out.write_str("<del")?,
-                        Container::Strong => out.write_str("<strong")?,
-                        Container::Emphasis => out.write_str("<em")?,
-                        Container::Mark => out.write_str("<mark")?,
                     }
-
-                    for (a, v) in attrs.iter().filter(|(a, _)| *a != "class") {
-                        write!(out, r#" {}=""#, a)?;
-                        v.parts().try_for_each(|part| write_attr(part, &mut out))?;
-                        out.write_char('"')?;
+                    Container::ListItem | Container::TaskListItem { .. } => {
+                        out.write_str("<li")?;
                     }
-
-                    if let Container::Heading {
-                        id,
-                        has_section: false,
-                        ..
+                    Container::DescriptionList => out.write_str("<dl")?,
+                    Container::DescriptionDetails => out.write_str("<dd")?,
+                    Container::Footnote { number, .. } => {
+                        assert!(self.footnote_number.is_none());
+                        self.footnote_number = Some((*number).try_into().unwrap());
+                        if !self.encountered_footnote {
+                            self.encountered_footnote = true;
+                            out.write_str("<section role=\"doc-endnotes\">\n<hr>\n<ol>\n")?;
+                        }
+                        write!(out, "<li id=\"fn{}\">", number)?;
+                        return Ok(());
                     }
-                    | Container::Section { id } = &c
-                    {
-                        if !attrs.iter().any(|(a, _)| a == "id") {
-                            out.write_str(r#" id=""#)?;
-                            write_attr(id, &mut out)?;
+                    Container::Table => out.write_str("<table")?,
+                    Container::TableRow { .. } => out.write_str("<tr")?,
+                    Container::Section { .. } => out.write_str("<section")?,
+                    Container::Div { .. } => out.write_str("<div")?,
+                    Container::Paragraph => {
+                        if matches!(self.list_tightness.last(), Some(true)) {
+                            return Ok(());
+                        }
+                        out.write_str("<p")?;
+                    }
+                    Container::Heading { level, .. } => write!(out, "<h{}", level)?,
+                    Container::TableCell { head: false, .. } => out.write_str("<td")?,
+                    Container::TableCell { head: true, .. } => out.write_str("<th")?,
+                    Container::Caption => out.write_str("<caption")?,
+                    Container::DescriptionTerm => out.write_str("<dt")?,
+                    Container::CodeBlock { .. } => out.write_str("<pre")?,
+                    Container::Span | Container::Math { .. } => out.write_str("<span")?,
+                    Container::Link(dst, ty) => {
+                        if matches!(ty, LinkType::Span(SpanLinkType::Unresolved)) {
+                            out.write_str("<a")?;
+                        } else {
+                            out.write_str(r#"<a href=""#)?;
+                            if matches!(ty, LinkType::Email) {
+                                out.write_str("mailto:")?;
+                            }
+                            write_attr(dst, &mut out)?;
                             out.write_char('"')?;
                         }
                     }
+                    Container::Image(..) => {
+                        self.img_alt_text += 1;
+                        if self.img_alt_text == 1 {
+                            out.write_str("<img")?;
+                        } else {
+                            return Ok(());
+                        }
+                    }
+                    Container::Verbatim => out.write_str("<code")?,
+                    Container::RawBlock { format } | Container::RawInline { format } => {
+                        self.raw = if format == &"html" {
+                            Raw::Html
+                        } else {
+                            Raw::Other
+                        };
+                        return Ok(());
+                    }
+                    Container::Subscript => out.write_str("<sub")?,
+                    Container::Superscript => out.write_str("<sup")?,
+                    Container::Insert => out.write_str("<ins")?,
+                    Container::Delete => out.write_str("<del")?,
+                    Container::Strong => out.write_str("<strong")?,
+                    Container::Emphasis => out.write_str("<em")?,
+                    Container::Mark => out.write_str("<mark")?,
+                }
 
-                    if attrs.iter().any(|(a, _)| a == "class")
-                        || matches!(
-                            c,
-                            Container::Div { class: Some(_) }
-                                | Container::Math { .. }
-                                | Container::List {
-                                    kind: ListKind::Task,
-                                    ..
-                                }
-                                | Container::TaskListItem { .. }
-                        )
-                    {
-                        out.write_str(r#" class=""#)?;
-                        let mut first_written = false;
-                        if let Some(cls) = match c {
-                            Container::List {
+                for (a, v) in attrs.iter().filter(|(a, _)| *a != "class") {
+                    write!(out, r#" {}=""#, a)?;
+                    v.parts().try_for_each(|part| write_attr(part, &mut out))?;
+                    out.write_char('"')?;
+                }
+
+                if let Container::Heading {
+                    id,
+                    has_section: false,
+                    ..
+                }
+                | Container::Section { id } = &c
+                {
+                    if !attrs.iter().any(|(a, _)| a == "id") {
+                        out.write_str(r#" id=""#)?;
+                        write_attr(id, &mut out)?;
+                        out.write_char('"')?;
+                    }
+                }
+
+                if attrs.iter().any(|(a, _)| a == "class")
+                    || matches!(
+                        c,
+                        Container::Div { class: Some(_) }
+                            | Container::Math { .. }
+                            | Container::List {
                                 kind: ListKind::Task,
                                 ..
-                            } => Some("task-list"),
-                            Container::TaskListItem { checked: false } => Some("unchecked"),
-                            Container::TaskListItem { checked: true } => Some("checked"),
-                            Container::Math { display: false } => Some("math inline"),
-                            Container::Math { display: true } => Some("math display"),
-                            _ => None,
-                        } {
-                            first_written = true;
-                            out.write_str(cls)?;
-                        }
-                        for cls in attrs
-                            .iter()
-                            .filter(|(a, _)| a == &"class")
-                            .map(|(_, cls)| cls)
-                        {
-                            if first_written {
-                                out.write_char(' ')?;
                             }
-                            first_written = true;
-                            cls.parts()
-                                .try_for_each(|part| write_attr(part, &mut out))?;
-                        }
-                        // div class goes after classes from attrs
-                        if let Container::Div { class: Some(cls) } = c {
-                            if first_written {
-                                out.write_char(' ')?;
-                            }
-                            out.write_str(cls)?;
-                        }
-                        out.write_char('"')?;
+                            | Container::TaskListItem { .. }
+                    )
+                {
+                    out.write_str(r#" class=""#)?;
+                    let mut first_written = false;
+                    if let Some(cls) = match c {
+                        Container::List {
+                            kind: ListKind::Task,
+                            ..
+                        } => Some("task-list"),
+                        Container::TaskListItem { checked: false } => Some("unchecked"),
+                        Container::TaskListItem { checked: true } => Some("checked"),
+                        Container::Math { display: false } => Some("math inline"),
+                        Container::Math { display: true } => Some("math display"),
+                        _ => None,
+                    } {
+                        first_written = true;
+                        out.write_str(cls)?;
                     }
+                    for cls in attrs
+                        .iter()
+                        .filter(|(a, _)| a == &"class")
+                        .map(|(_, cls)| cls)
+                    {
+                        if first_written {
+                            out.write_char(' ')?;
+                        }
+                        first_written = true;
+                        cls.parts()
+                            .try_for_each(|part| write_attr(part, &mut out))?;
+                    }
+                    // div class goes after classes from attrs
+                    if let Container::Div { class: Some(cls) } = c {
+                        if first_written {
+                            out.write_char(' ')?;
+                        }
+                        out.write_str(cls)?;
+                    }
+                    out.write_char('"')?;
+                }
 
-                    match c {
-                        Container::TableCell { alignment, .. }
-                            if !matches!(alignment, Alignment::Unspecified) =>
-                        {
-                            let a = match alignment {
-                                Alignment::Unspecified => unreachable!(),
-                                Alignment::Left => "left",
-                                Alignment::Center => "center",
-                                Alignment::Right => "right",
-                            };
-                            write!(out, r#" style="text-align: {};">"#, a)?;
-                        }
-                        Container::CodeBlock { lang } => {
-                            if let Some(l) = lang {
-                                out.write_str(r#"><code class="language-"#)?;
-                                write_attr(l, &mut out)?;
-                                out.write_str(r#"">"#)?;
-                            } else {
-                                out.write_str("><code>")?;
-                            }
-                        }
-                        Container::Image(..) => {
-                            if self.img_alt_text == 1 {
-                                out.write_str(r#" alt=""#)?;
-                            }
-                        }
-                        Container::Math { display } => {
-                            out.write_str(if display { r#">\["# } else { r#">\("# })?;
-                        }
-                        _ => out.write_char('>')?,
+                match c {
+                    Container::TableCell { alignment, .. }
+                        if !matches!(alignment, Alignment::Unspecified) =>
+                    {
+                        let a = match alignment {
+                            Alignment::Unspecified => unreachable!(),
+                            Alignment::Left => "left",
+                            Alignment::Center => "center",
+                            Alignment::Right => "right",
+                        };
+                        write!(out, r#" style="text-align: {};">"#, a)?;
                     }
-                }
-                Event::End(c) => {
-                    if c.is_block_container() && !matches!(c, Container::Footnote { .. }) {
-                        out.write_char('\n')?;
+                    Container::CodeBlock { lang } => {
+                        if let Some(l) = lang {
+                            out.write_str(r#"><code class="language-"#)?;
+                            write_attr(l, &mut out)?;
+                            out.write_str(r#"">"#)?;
+                        } else {
+                            out.write_str("><code>")?;
+                        }
                     }
-                    if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
-                        continue;
+                    Container::Image(..) => {
+                        if self.img_alt_text == 1 {
+                            out.write_str(r#" alt=""#)?;
+                        }
                     }
-                    match c {
-                        Container::Blockquote => out.write_str("</blockquote>")?,
-                        Container::List {
-                            kind: ListKind::Unordered | ListKind::Task,
-                            ..
-                        } => {
-                            self.list_tightness.pop();
-                            out.write_str("</ul>")?;
-                        }
-                        Container::List {
-                            kind: ListKind::Ordered { .. },
-                            ..
-                        } => out.write_str("</ol>")?,
-                        Container::ListItem | Container::TaskListItem { .. } => {
-                            out.write_str("</li>")?;
-                        }
-                        Container::DescriptionList => out.write_str("</dl>")?,
-                        Container::DescriptionDetails => out.write_str("</dd>")?,
-                        Container::Footnote { number, .. } => {
-                            if !close_para {
-                                // create a new paragraph
-                                out.write_str("\n<p>")?;
-                            }
-                            write!(
-                                out,
-                                r##"<a href="#fnref{}" role="doc-backlink">↩︎︎</a></p>"##,
-                                number,
-                            )?;
-                            out.write_str("\n</li>")?;
-                            self.footnote_number = None;
-                        }
-                        Container::Table => out.write_str("</table>")?,
-                        Container::TableRow { .. } => out.write_str("</tr>")?,
-                        Container::Section { .. } => out.write_str("</section>")?,
-                        Container::Div { .. } => out.write_str("</div>")?,
-                        Container::Paragraph => {
-                            if matches!(self.list_tightness.last(), Some(true)) {
-                                continue;
-                            }
-                            if self.footnote_number.is_none() {
-                                out.write_str("</p>")?;
-                            } else {
-                                self.close_para = true;
-                            }
-                        }
-                        Container::Heading { level, .. } => write!(out, "</h{}>", level)?,
-                        Container::TableCell { head: false, .. } => out.write_str("</td>")?,
-                        Container::TableCell { head: true, .. } => out.write_str("</th>")?,
-                        Container::Caption => out.write_str("</caption>")?,
-                        Container::DescriptionTerm => out.write_str("</dt>")?,
-                        Container::CodeBlock { .. } => out.write_str("</code></pre>")?,
-                        Container::Span => out.write_str("</span>")?,
-                        Container::Link(..) => out.write_str("</a>")?,
-                        Container::Image(src, ..) => {
-                            if self.img_alt_text == 1 {
-                                if !src.is_empty() {
-                                    out.write_str(r#"" src=""#)?;
-                                    write_attr(&src, &mut out)?;
-                                }
-                                out.write_str(r#"">"#)?;
-                            }
-                            self.img_alt_text -= 1;
-                        }
-                        Container::Verbatim => out.write_str("</code>")?,
-                        Container::Math { display } => {
-                            out.write_str(if display {
-                                r#"\]</span>"#
-                            } else {
-                                r#"\)</span>"#
-                            })?;
-                        }
-                        Container::RawBlock { .. } | Container::RawInline { .. } => {
-                            self.raw = Raw::None;
-                        }
-                        Container::Subscript => out.write_str("</sub>")?,
-                        Container::Superscript => out.write_str("</sup>")?,
-                        Container::Insert => out.write_str("</ins>")?,
-                        Container::Delete => out.write_str("</del>")?,
-                        Container::Strong => out.write_str("</strong>")?,
-                        Container::Emphasis => out.write_str("</em>")?,
-                        Container::Mark => out.write_str("</mark>")?,
+                    Container::Math { display } => {
+                        out.write_str(if *display { r#">\["# } else { r#">\("# })?;
                     }
-                }
-                Event::Str(s) => match self.raw {
-                    Raw::None if self.img_alt_text > 0 => write_attr(&s, &mut out)?,
-                    Raw::None => write_text(&s, &mut out)?,
-                    Raw::Html => out.write_str(&s)?,
-                    Raw::Other => {}
-                },
-                Event::FootnoteReference(_tag, number) => {
-                    if self.img_alt_text == 0 {
-                        write!(
-                            out,
-                            r##"<a id="fnref{}" href="#fn{}" role="doc-noteref"><sup>{}</sup></a>"##,
-                            number, number, number
-                        )?;
-                    }
-                }
-                Event::Symbol(sym) => write!(out, ":{}:", sym)?,
-                Event::LeftSingleQuote => out.write_str("&lsquo;")?,
-                Event::RightSingleQuote => out.write_str("&rsquo;")?,
-                Event::LeftDoubleQuote => out.write_str("&ldquo;")?,
-                Event::RightDoubleQuote => out.write_str("&rdquo;")?,
-                Event::Ellipsis => out.write_str("&hellip;")?,
-                Event::EnDash => out.write_str("&ndash;")?,
-                Event::EmDash => out.write_str("&mdash;")?,
-                Event::NonBreakingSpace => out.write_str("&nbsp;")?,
-                Event::Hardbreak => out.write_str("<br>\n")?,
-                Event::Softbreak => out.write_char('\n')?,
-                Event::Escape | Event::Blankline => unreachable!("filtered out"),
-                Event::ThematicBreak(attrs) => {
-                    out.write_str("\n<hr")?;
-                    for (a, v) in attrs.iter() {
-                        write!(out, r#" {}=""#, a)?;
-                        v.parts().try_for_each(|part| write_attr(part, &mut out))?;
-                        out.write_char('"')?;
-                    }
-                    out.write_str(">")?;
+                    _ => out.write_char('>')?,
                 }
             }
-            self.first_line = false;
+            Event::End(c) => {
+                if c.is_block_container() && !matches!(c, Container::Footnote { .. }) {
+                    out.write_char('\n')?;
+                }
+                if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
+                    return Ok(());
+                }
+                match c {
+                    Container::Blockquote => out.write_str("</blockquote>")?,
+                    Container::List {
+                        kind: ListKind::Unordered | ListKind::Task,
+                        ..
+                    } => {
+                        self.list_tightness.pop();
+                        out.write_str("</ul>")?;
+                    }
+                    Container::List {
+                        kind: ListKind::Ordered { .. },
+                        ..
+                    } => out.write_str("</ol>")?,
+                    Container::ListItem | Container::TaskListItem { .. } => {
+                        out.write_str("</li>")?;
+                    }
+                    Container::DescriptionList => out.write_str("</dl>")?,
+                    Container::DescriptionDetails => out.write_str("</dd>")?,
+                    Container::Footnote { number, .. } => {
+                        if !close_para {
+                            // create a new paragraph
+                            out.write_str("\n<p>")?;
+                        }
+                        write!(
+                            out,
+                            r##"<a href="#fnref{}" role="doc-backlink">↩︎︎</a></p>"##,
+                            number,
+                        )?;
+                        out.write_str("\n</li>")?;
+                        self.footnote_number = None;
+                    }
+                    Container::Table => out.write_str("</table>")?,
+                    Container::TableRow { .. } => out.write_str("</tr>")?,
+                    Container::Section { .. } => out.write_str("</section>")?,
+                    Container::Div { .. } => out.write_str("</div>")?,
+                    Container::Paragraph => {
+                        if matches!(self.list_tightness.last(), Some(true)) {
+                            return Ok(());
+                        }
+                        if self.footnote_number.is_none() {
+                            out.write_str("</p>")?;
+                        } else {
+                            self.close_para = true;
+                        }
+                    }
+                    Container::Heading { level, .. } => write!(out, "</h{}>", level)?,
+                    Container::TableCell { head: false, .. } => out.write_str("</td>")?,
+                    Container::TableCell { head: true, .. } => out.write_str("</th>")?,
+                    Container::Caption => out.write_str("</caption>")?,
+                    Container::DescriptionTerm => out.write_str("</dt>")?,
+                    Container::CodeBlock { .. } => out.write_str("</code></pre>")?,
+                    Container::Span => out.write_str("</span>")?,
+                    Container::Link(..) => out.write_str("</a>")?,
+                    Container::Image(src, ..) => {
+                        if self.img_alt_text == 1 {
+                            if !src.is_empty() {
+                                out.write_str(r#"" src=""#)?;
+                                write_attr(src, &mut out)?;
+                            }
+                            out.write_str(r#"">"#)?;
+                        }
+                        self.img_alt_text -= 1;
+                    }
+                    Container::Verbatim => out.write_str("</code>")?,
+                    Container::Math { display } => {
+                        out.write_str(if *display {
+                            r#"\]</span>"#
+                        } else {
+                            r#"\)</span>"#
+                        })?;
+                    }
+                    Container::RawBlock { .. } | Container::RawInline { .. } => {
+                        self.raw = Raw::None;
+                    }
+                    Container::Subscript => out.write_str("</sub>")?,
+                    Container::Superscript => out.write_str("</sup>")?,
+                    Container::Insert => out.write_str("</ins>")?,
+                    Container::Delete => out.write_str("</del>")?,
+                    Container::Strong => out.write_str("</strong>")?,
+                    Container::Emphasis => out.write_str("</em>")?,
+                    Container::Mark => out.write_str("</mark>")?,
+                }
+            }
+            Event::Str(s) => match self.raw {
+                Raw::None if self.img_alt_text > 0 => write_attr(s, &mut out)?,
+                Raw::None => write_text(s, &mut out)?,
+                Raw::Html => out.write_str(s)?,
+                Raw::Other => {}
+            },
+            Event::FootnoteReference(_tag, number) => {
+                if self.img_alt_text == 0 {
+                    write!(
+                        out,
+                        r##"<a id="fnref{}" href="#fn{}" role="doc-noteref"><sup>{}</sup></a>"##,
+                        number, number, number
+                    )?;
+                }
+            }
+            Event::Symbol(sym) => write!(out, ":{}:", sym)?,
+            Event::LeftSingleQuote => out.write_str("&lsquo;")?,
+            Event::RightSingleQuote => out.write_str("&rsquo;")?,
+            Event::LeftDoubleQuote => out.write_str("&ldquo;")?,
+            Event::RightDoubleQuote => out.write_str("&rdquo;")?,
+            Event::Ellipsis => out.write_str("&hellip;")?,
+            Event::EnDash => out.write_str("&ndash;")?,
+            Event::EmDash => out.write_str("&mdash;")?,
+            Event::NonBreakingSpace => out.write_str("&nbsp;")?,
+            Event::Hardbreak => out.write_str("<br>\n")?,
+            Event::Softbreak => out.write_char('\n')?,
+            Event::Escape | Event::Blankline => unreachable!("filtered out"),
+            Event::ThematicBreak(attrs) => {
+                out.write_str("\n<hr")?;
+                for (a, v) in attrs.iter() {
+                    write!(out, r#" {}=""#, a)?;
+                    v.parts().try_for_each(|part| write_attr(part, &mut out))?;
+                    out.write_char('"')?;
+                }
+                out.write_str(">")?;
+            }
         }
+        self.first_line = false;
+
+        Ok(())
+    }
+
+    fn render_epilogue<W>(&mut self, mut out: W) -> std::fmt::Result
+    where
+        W: std::fmt::Write,
+    {
         if self.encountered_footnote {
             out.write_str("\n</ol>\n</section>")?;
         }
         out.write_char('\n')?;
+
         Ok(())
     }
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -39,7 +39,7 @@ impl Render for Renderer {
         events: I,
         out: W,
     ) -> std::fmt::Result {
-        Writer::new(events, out).write()
+        Writer::default().write(events, out)
     }
 }
 
@@ -49,9 +49,7 @@ enum Raw {
     Other,
 }
 
-struct Writer<'s, I: Iterator<Item = Event<'s>>, W> {
-    events: I,
-    out: W,
+struct Writer {
     raw: Raw,
     img_alt_text: usize,
     list_tightness: Vec<bool>,
@@ -61,11 +59,9 @@ struct Writer<'s, I: Iterator<Item = Event<'s>>, W> {
     close_para: bool,
 }
 
-impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
-    fn new(events: I, out: W) -> Self {
+impl Default for Writer {
+    fn default() -> Self {
         Self {
-            events,
-            out,
             raw: Raw::None,
             img_alt_text: 0,
             list_tightness: Vec::new(),
@@ -75,9 +71,15 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
             close_para: false,
         }
     }
+}
 
-    fn write(&mut self) -> std::fmt::Result {
-        while let Some(e) = self.events.next() {
+impl Writer {
+    fn write<'s>(
+        &mut self,
+        events: impl Iterator<Item = Event<'s>>,
+        mut out: impl std::fmt::Write,
+    ) -> std::fmt::Result {
+        for e in events {
             if matches!(&e, Event::Blankline | Event::Escape) {
                 continue;
             }
@@ -87,32 +89,30 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                 self.close_para = false;
                 if !matches!(&e, Event::End(Container::Footnote { .. })) {
                     // no need to add href before para close
-                    self.out.write_str("</p>")?;
+                    out.write_str("</p>")?;
                 }
             }
 
             match e {
                 Event::Start(c, attrs) => {
                     if c.is_block() && !self.first_line {
-                        self.out.write_char('\n')?;
+                        out.write_char('\n')?;
                     }
                     if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
                         continue;
                     }
                     match &c {
-                        Container::Blockquote => self.out.write_str("<blockquote")?,
+                        Container::Blockquote => out.write_str("<blockquote")?,
                         Container::List { kind, tight } => {
                             self.list_tightness.push(*tight);
                             match kind {
-                                ListKind::Unordered | ListKind::Task => {
-                                    self.out.write_str("<ul")?
-                                }
+                                ListKind::Unordered | ListKind::Task => out.write_str("<ul")?,
                                 ListKind::Ordered {
                                     numbering, start, ..
                                 } => {
-                                    self.out.write_str("<ol")?;
+                                    out.write_str("<ol")?;
                                     if *start > 1 {
-                                        write!(self.out, r#" start="{}""#, start)?;
+                                        write!(out, r#" start="{}""#, start)?;
                                     }
                                     if let Some(ty) = match numbering {
                                         Decimal => None,
@@ -121,65 +121,64 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                                         RomanLower => Some('i'),
                                         RomanUpper => Some('I'),
                                     } {
-                                        write!(self.out, r#" type="{}""#, ty)?;
+                                        write!(out, r#" type="{}""#, ty)?;
                                     }
                                 }
                             }
                         }
                         Container::ListItem | Container::TaskListItem { .. } => {
-                            self.out.write_str("<li")?;
+                            out.write_str("<li")?;
                         }
-                        Container::DescriptionList => self.out.write_str("<dl")?,
-                        Container::DescriptionDetails => self.out.write_str("<dd")?,
+                        Container::DescriptionList => out.write_str("<dl")?,
+                        Container::DescriptionDetails => out.write_str("<dd")?,
                         Container::Footnote { number, .. } => {
                             assert!(self.footnote_number.is_none());
                             self.footnote_number = Some((*number).try_into().unwrap());
                             if !self.encountered_footnote {
                                 self.encountered_footnote = true;
-                                self.out
-                                    .write_str("<section role=\"doc-endnotes\">\n<hr>\n<ol>\n")?;
+                                out.write_str("<section role=\"doc-endnotes\">\n<hr>\n<ol>\n")?;
                             }
-                            write!(self.out, "<li id=\"fn{}\">", number)?;
+                            write!(out, "<li id=\"fn{}\">", number)?;
                             continue;
                         }
-                        Container::Table => self.out.write_str("<table")?,
-                        Container::TableRow { .. } => self.out.write_str("<tr")?,
-                        Container::Section { .. } => self.out.write_str("<section")?,
-                        Container::Div { .. } => self.out.write_str("<div")?,
+                        Container::Table => out.write_str("<table")?,
+                        Container::TableRow { .. } => out.write_str("<tr")?,
+                        Container::Section { .. } => out.write_str("<section")?,
+                        Container::Div { .. } => out.write_str("<div")?,
                         Container::Paragraph => {
                             if matches!(self.list_tightness.last(), Some(true)) {
                                 continue;
                             }
-                            self.out.write_str("<p")?;
+                            out.write_str("<p")?;
                         }
-                        Container::Heading { level, .. } => write!(self.out, "<h{}", level)?,
-                        Container::TableCell { head: false, .. } => self.out.write_str("<td")?,
-                        Container::TableCell { head: true, .. } => self.out.write_str("<th")?,
-                        Container::Caption => self.out.write_str("<caption")?,
-                        Container::DescriptionTerm => self.out.write_str("<dt")?,
-                        Container::CodeBlock { .. } => self.out.write_str("<pre")?,
-                        Container::Span | Container::Math { .. } => self.out.write_str("<span")?,
+                        Container::Heading { level, .. } => write!(out, "<h{}", level)?,
+                        Container::TableCell { head: false, .. } => out.write_str("<td")?,
+                        Container::TableCell { head: true, .. } => out.write_str("<th")?,
+                        Container::Caption => out.write_str("<caption")?,
+                        Container::DescriptionTerm => out.write_str("<dt")?,
+                        Container::CodeBlock { .. } => out.write_str("<pre")?,
+                        Container::Span | Container::Math { .. } => out.write_str("<span")?,
                         Container::Link(dst, ty) => {
                             if matches!(ty, LinkType::Span(SpanLinkType::Unresolved)) {
-                                self.out.write_str("<a")?;
+                                out.write_str("<a")?;
                             } else {
-                                self.out.write_str(r#"<a href=""#)?;
+                                out.write_str(r#"<a href=""#)?;
                                 if matches!(ty, LinkType::Email) {
-                                    self.out.write_str("mailto:")?;
+                                    out.write_str("mailto:")?;
                                 }
-                                self.write_attr(dst)?;
-                                self.out.write_char('"')?;
+                                write_attr(dst, &mut out)?;
+                                out.write_char('"')?;
                             }
                         }
                         Container::Image(..) => {
                             self.img_alt_text += 1;
                             if self.img_alt_text == 1 {
-                                self.out.write_str("<img")?;
+                                out.write_str("<img")?;
                             } else {
                                 continue;
                             }
                         }
-                        Container::Verbatim => self.out.write_str("<code")?,
+                        Container::Verbatim => out.write_str("<code")?,
                         Container::RawBlock { format } | Container::RawInline { format } => {
                             self.raw = if format == &"html" {
                                 Raw::Html
@@ -188,19 +187,19 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                             };
                             continue;
                         }
-                        Container::Subscript => self.out.write_str("<sub")?,
-                        Container::Superscript => self.out.write_str("<sup")?,
-                        Container::Insert => self.out.write_str("<ins")?,
-                        Container::Delete => self.out.write_str("<del")?,
-                        Container::Strong => self.out.write_str("<strong")?,
-                        Container::Emphasis => self.out.write_str("<em")?,
-                        Container::Mark => self.out.write_str("<mark")?,
+                        Container::Subscript => out.write_str("<sub")?,
+                        Container::Superscript => out.write_str("<sup")?,
+                        Container::Insert => out.write_str("<ins")?,
+                        Container::Delete => out.write_str("<del")?,
+                        Container::Strong => out.write_str("<strong")?,
+                        Container::Emphasis => out.write_str("<em")?,
+                        Container::Mark => out.write_str("<mark")?,
                     }
 
                     for (a, v) in attrs.iter().filter(|(a, _)| *a != "class") {
-                        write!(self.out, r#" {}=""#, a)?;
-                        v.parts().try_for_each(|part| self.write_attr(part))?;
-                        self.out.write_char('"')?;
+                        write!(out, r#" {}=""#, a)?;
+                        v.parts().try_for_each(|part| write_attr(part, &mut out))?;
+                        out.write_char('"')?;
                     }
 
                     if let Container::Heading {
@@ -211,9 +210,9 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                     | Container::Section { id } = &c
                     {
                         if !attrs.iter().any(|(a, _)| a == "id") {
-                            self.out.write_str(r#" id=""#)?;
-                            self.write_attr(id)?;
-                            self.out.write_char('"')?;
+                            out.write_str(r#" id=""#)?;
+                            write_attr(id, &mut out)?;
+                            out.write_char('"')?;
                         }
                     }
 
@@ -229,7 +228,7 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                                 | Container::TaskListItem { .. }
                         )
                     {
-                        self.out.write_str(r#" class=""#)?;
+                        out.write_str(r#" class=""#)?;
                         let mut first_written = false;
                         if let Some(cls) = match c {
                             Container::List {
@@ -243,7 +242,7 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                             _ => None,
                         } {
                             first_written = true;
-                            self.out.write_str(cls)?;
+                            out.write_str(cls)?;
                         }
                         for cls in attrs
                             .iter()
@@ -251,19 +250,20 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                             .map(|(_, cls)| cls)
                         {
                             if first_written {
-                                self.out.write_char(' ')?;
+                                out.write_char(' ')?;
                             }
                             first_written = true;
-                            cls.parts().try_for_each(|part| self.write_attr(part))?;
+                            cls.parts()
+                                .try_for_each(|part| write_attr(part, &mut out))?;
                         }
                         // div class goes after classes from attrs
                         if let Container::Div { class: Some(cls) } = c {
                             if first_written {
-                                self.out.write_char(' ')?;
+                                out.write_char(' ')?;
                             }
-                            self.out.write_str(cls)?;
+                            out.write_str(cls)?;
                         }
-                        self.out.write_char('"')?;
+                        out.write_char('"')?;
                     }
 
                     match c {
@@ -276,102 +276,101 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                                 Alignment::Center => "center",
                                 Alignment::Right => "right",
                             };
-                            write!(self.out, r#" style="text-align: {};">"#, a)?;
+                            write!(out, r#" style="text-align: {};">"#, a)?;
                         }
                         Container::CodeBlock { lang } => {
                             if let Some(l) = lang {
-                                self.out.write_str(r#"><code class="language-"#)?;
-                                self.write_attr(l)?;
-                                self.out.write_str(r#"">"#)?;
+                                out.write_str(r#"><code class="language-"#)?;
+                                write_attr(l, &mut out)?;
+                                out.write_str(r#"">"#)?;
                             } else {
-                                self.out.write_str("><code>")?;
+                                out.write_str("><code>")?;
                             }
                         }
                         Container::Image(..) => {
                             if self.img_alt_text == 1 {
-                                self.out.write_str(r#" alt=""#)?;
+                                out.write_str(r#" alt=""#)?;
                             }
                         }
                         Container::Math { display } => {
-                            self.out
-                                .write_str(if display { r#">\["# } else { r#">\("# })?;
+                            out.write_str(if display { r#">\["# } else { r#">\("# })?;
                         }
-                        _ => self.out.write_char('>')?,
+                        _ => out.write_char('>')?,
                     }
                 }
                 Event::End(c) => {
                     if c.is_block_container() && !matches!(c, Container::Footnote { .. }) {
-                        self.out.write_char('\n')?;
+                        out.write_char('\n')?;
                     }
                     if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
                         continue;
                     }
                     match c {
-                        Container::Blockquote => self.out.write_str("</blockquote>")?,
+                        Container::Blockquote => out.write_str("</blockquote>")?,
                         Container::List {
                             kind: ListKind::Unordered | ListKind::Task,
                             ..
                         } => {
                             self.list_tightness.pop();
-                            self.out.write_str("</ul>")?;
+                            out.write_str("</ul>")?;
                         }
                         Container::List {
                             kind: ListKind::Ordered { .. },
                             ..
-                        } => self.out.write_str("</ol>")?,
+                        } => out.write_str("</ol>")?,
                         Container::ListItem | Container::TaskListItem { .. } => {
-                            self.out.write_str("</li>")?;
+                            out.write_str("</li>")?;
                         }
-                        Container::DescriptionList => self.out.write_str("</dl>")?,
-                        Container::DescriptionDetails => self.out.write_str("</dd>")?,
+                        Container::DescriptionList => out.write_str("</dl>")?,
+                        Container::DescriptionDetails => out.write_str("</dd>")?,
                         Container::Footnote { number, .. } => {
                             if !close_para {
                                 // create a new paragraph
-                                self.out.write_str("\n<p>")?;
+                                out.write_str("\n<p>")?;
                             }
                             write!(
-                                self.out,
+                                out,
                                 r##"<a href="#fnref{}" role="doc-backlink">↩︎︎</a></p>"##,
                                 number,
                             )?;
-                            self.out.write_str("\n</li>")?;
+                            out.write_str("\n</li>")?;
                             self.footnote_number = None;
                         }
-                        Container::Table => self.out.write_str("</table>")?,
-                        Container::TableRow { .. } => self.out.write_str("</tr>")?,
-                        Container::Section { .. } => self.out.write_str("</section>")?,
-                        Container::Div { .. } => self.out.write_str("</div>")?,
+                        Container::Table => out.write_str("</table>")?,
+                        Container::TableRow { .. } => out.write_str("</tr>")?,
+                        Container::Section { .. } => out.write_str("</section>")?,
+                        Container::Div { .. } => out.write_str("</div>")?,
                         Container::Paragraph => {
                             if matches!(self.list_tightness.last(), Some(true)) {
                                 continue;
                             }
                             if self.footnote_number.is_none() {
-                                self.out.write_str("</p>")?;
+                                out.write_str("</p>")?;
                             } else {
                                 self.close_para = true;
                             }
                         }
-                        Container::Heading { level, .. } => write!(self.out, "</h{}>", level)?,
-                        Container::TableCell { head: false, .. } => self.out.write_str("</td>")?,
-                        Container::TableCell { head: true, .. } => self.out.write_str("</th>")?,
-                        Container::Caption => self.out.write_str("</caption>")?,
-                        Container::DescriptionTerm => self.out.write_str("</dt>")?,
-                        Container::CodeBlock { .. } => self.out.write_str("</code></pre>")?,
-                        Container::Span => self.out.write_str("</span>")?,
-                        Container::Link(..) => self.out.write_str("</a>")?,
+                        Container::Heading { level, .. } => write!(out, "</h{}>", level)?,
+                        Container::TableCell { head: false, .. } => out.write_str("</td>")?,
+                        Container::TableCell { head: true, .. } => out.write_str("</th>")?,
+                        Container::Caption => out.write_str("</caption>")?,
+                        Container::DescriptionTerm => out.write_str("</dt>")?,
+                        Container::CodeBlock { .. } => out.write_str("</code></pre>")?,
+                        Container::Span => out.write_str("</span>")?,
+                        Container::Link(..) => out.write_str("</a>")?,
                         Container::Image(src, ..) => {
                             if self.img_alt_text == 1 {
                                 if !src.is_empty() {
-                                    self.out.write_str(r#"" src=""#)?;
-                                    self.write_attr(&src)?;
+                                    out.write_str(r#"" src=""#)?;
+                                    write_attr(&src, &mut out)?;
                                 }
-                                self.out.write_str(r#"">"#)?;
+                                out.write_str(r#"">"#)?;
                             }
                             self.img_alt_text -= 1;
                         }
-                        Container::Verbatim => self.out.write_str("</code>")?,
+                        Container::Verbatim => out.write_str("</code>")?,
                         Container::Math { display } => {
-                            self.out.write_str(if display {
+                            out.write_str(if display {
                                 r#"\]</span>"#
                             } else {
                                 r#"\)</span>"#
@@ -380,88 +379,97 @@ impl<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write> Writer<'s, I, W> {
                         Container::RawBlock { .. } | Container::RawInline { .. } => {
                             self.raw = Raw::None;
                         }
-                        Container::Subscript => self.out.write_str("</sub>")?,
-                        Container::Superscript => self.out.write_str("</sup>")?,
-                        Container::Insert => self.out.write_str("</ins>")?,
-                        Container::Delete => self.out.write_str("</del>")?,
-                        Container::Strong => self.out.write_str("</strong>")?,
-                        Container::Emphasis => self.out.write_str("</em>")?,
-                        Container::Mark => self.out.write_str("</mark>")?,
+                        Container::Subscript => out.write_str("</sub>")?,
+                        Container::Superscript => out.write_str("</sup>")?,
+                        Container::Insert => out.write_str("</ins>")?,
+                        Container::Delete => out.write_str("</del>")?,
+                        Container::Strong => out.write_str("</strong>")?,
+                        Container::Emphasis => out.write_str("</em>")?,
+                        Container::Mark => out.write_str("</mark>")?,
                     }
                 }
                 Event::Str(s) => match self.raw {
-                    Raw::None if self.img_alt_text > 0 => self.write_attr(&s)?,
-                    Raw::None => self.write_text(&s)?,
-                    Raw::Html => self.out.write_str(&s)?,
+                    Raw::None if self.img_alt_text > 0 => write_attr(&s, &mut out)?,
+                    Raw::None => write_text(&s, &mut out)?,
+                    Raw::Html => out.write_str(&s)?,
                     Raw::Other => {}
                 },
                 Event::FootnoteReference(_tag, number) => {
                     if self.img_alt_text == 0 {
                         write!(
-                            self.out,
+                            out,
                             r##"<a id="fnref{}" href="#fn{}" role="doc-noteref"><sup>{}</sup></a>"##,
                             number, number, number
                         )?;
                     }
                 }
-                Event::Symbol(sym) => write!(self.out, ":{}:", sym)?,
-                Event::LeftSingleQuote => self.out.write_str("&lsquo;")?,
-                Event::RightSingleQuote => self.out.write_str("&rsquo;")?,
-                Event::LeftDoubleQuote => self.out.write_str("&ldquo;")?,
-                Event::RightDoubleQuote => self.out.write_str("&rdquo;")?,
-                Event::Ellipsis => self.out.write_str("&hellip;")?,
-                Event::EnDash => self.out.write_str("&ndash;")?,
-                Event::EmDash => self.out.write_str("&mdash;")?,
-                Event::NonBreakingSpace => self.out.write_str("&nbsp;")?,
-                Event::Hardbreak => self.out.write_str("<br>\n")?,
-                Event::Softbreak => self.out.write_char('\n')?,
+                Event::Symbol(sym) => write!(out, ":{}:", sym)?,
+                Event::LeftSingleQuote => out.write_str("&lsquo;")?,
+                Event::RightSingleQuote => out.write_str("&rsquo;")?,
+                Event::LeftDoubleQuote => out.write_str("&ldquo;")?,
+                Event::RightDoubleQuote => out.write_str("&rdquo;")?,
+                Event::Ellipsis => out.write_str("&hellip;")?,
+                Event::EnDash => out.write_str("&ndash;")?,
+                Event::EmDash => out.write_str("&mdash;")?,
+                Event::NonBreakingSpace => out.write_str("&nbsp;")?,
+                Event::Hardbreak => out.write_str("<br>\n")?,
+                Event::Softbreak => out.write_char('\n')?,
                 Event::Escape | Event::Blankline => unreachable!("filtered out"),
                 Event::ThematicBreak(attrs) => {
-                    self.out.write_str("\n<hr")?;
+                    out.write_str("\n<hr")?;
                     for (a, v) in attrs.iter() {
-                        write!(self.out, r#" {}=""#, a)?;
-                        v.parts().try_for_each(|part| self.write_attr(part))?;
-                        self.out.write_char('"')?;
+                        write!(out, r#" {}=""#, a)?;
+                        v.parts().try_for_each(|part| write_attr(part, &mut out))?;
+                        out.write_char('"')?;
                     }
-                    self.out.write_str(">")?;
+                    out.write_str(">")?;
                 }
             }
             self.first_line = false;
         }
         if self.encountered_footnote {
-            self.out.write_str("\n</ol>\n</section>")?;
+            out.write_str("\n</ol>\n</section>")?;
         }
-        self.out.write_char('\n')?;
+        out.write_char('\n')?;
         Ok(())
     }
+}
 
-    fn write_escape(&mut self, mut s: &str, escape_quotes: bool) -> std::fmt::Result {
-        let mut ent = "";
-        while let Some(i) = s.find(|c| {
-            match c {
-                '<' => Some("&lt;"),
-                '>' => Some("&gt;"),
-                '&' => Some("&amp;"),
-                '"' if escape_quotes => Some("&quot;"),
-                _ => None,
-            }
-            .map_or(false, |s| {
-                ent = s;
-                true
-            })
-        }) {
-            self.out.write_str(&s[..i])?;
-            self.out.write_str(ent)?;
-            s = &s[i + 1..];
+fn write_text<W>(s: &str, out: W) -> std::fmt::Result
+where
+    W: std::fmt::Write,
+{
+    write_escape(s, false, out)
+}
+
+fn write_attr<W>(s: &str, out: W) -> std::fmt::Result
+where
+    W: std::fmt::Write,
+{
+    write_escape(s, true, out)
+}
+
+fn write_escape<W>(mut s: &str, escape_quotes: bool, mut out: W) -> std::fmt::Result
+where
+    W: std::fmt::Write,
+{
+    let mut ent = "";
+    while let Some(i) = s.find(|c| {
+        match c {
+            '<' => Some("&lt;"),
+            '>' => Some("&gt;"),
+            '&' => Some("&amp;"),
+            '"' if escape_quotes => Some("&quot;"),
+            _ => None,
         }
-        self.out.write_str(s)
+        .map_or(false, |s| {
+            ent = s;
+            true
+        })
+    }) {
+        out.write_str(&s[..i])?;
+        out.write_str(ent)?;
+        s = &s[i + 1..];
     }
-
-    fn write_text(&mut self, s: &str) -> std::fmt::Result {
-        self.write_escape(s, false)
-    }
-
-    fn write_attr(&mut self, s: &str) -> std::fmt::Result {
-        self.write_escape(s, true)
-    }
+    out.write_str(s)
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,26 +1,4 @@
 //! An HTML renderer that takes an iterator of [`Event`]s and emits HTML.
-//!
-//! The HTML can be written to either a [`std::fmt::Write`] or a [`std::io::Write`] object.
-//!
-//! # Examples
-//!
-//! Push to a [`String`] (implements [`std::fmt::Write`]):
-//!
-//! ```
-//! # use jotdown::Render;
-//! # let events = std::iter::empty();
-//! let mut html = String::new();
-//! jotdown::html::Renderer.push(events, &mut html);
-//! ```
-//!
-//! Write to standard output with buffering ([`std::io::Stdout`] implements [`std::io::Write`]):
-//!
-//! ```
-//! # use jotdown::Render;
-//! # let events = std::iter::empty();
-//! let mut out = std::io::BufWriter::new(std::io::stdout());
-//! jotdown::html::Renderer.write(events, &mut out).unwrap();
-//! ```
 
 use crate::Alignment;
 use crate::Container;

--- a/src/html.rs
+++ b/src/html.rs
@@ -9,25 +9,13 @@ use crate::OrderedListNumbering::*;
 use crate::Render;
 use crate::SpanLinkType;
 
-pub struct Renderer;
-
-impl Render for Renderer {
-    fn push<'s, I: Iterator<Item = Event<'s>>, W: std::fmt::Write>(
-        &self,
-        events: I,
-        out: W,
-    ) -> std::fmt::Result {
-        Writer::default().write(events, out)
-    }
-}
-
 enum Raw {
     None,
     Html,
     Other,
 }
 
-struct Writer {
+pub struct Renderer {
     raw: Raw,
     img_alt_text: usize,
     list_tightness: Vec<bool>,
@@ -37,7 +25,7 @@ struct Writer {
     close_para: bool,
 }
 
-impl Default for Writer {
+impl Default for Renderer {
     fn default() -> Self {
         Self {
             raw: Raw::None,
@@ -51,16 +39,7 @@ impl Default for Writer {
     }
 }
 
-impl Writer {
-    fn write<'s, I, W>(&mut self, mut events: I, mut out: W) -> std::fmt::Result
-    where
-        I: Iterator<Item = Event<'s>>,
-        W: std::fmt::Write,
-    {
-        events.try_for_each(|e| self.render_event(&e, &mut out))?;
-        self.render_epilogue(&mut out)
-    }
-
+impl Render for Renderer {
     fn render_event<'s, W>(&mut self, e: &Event<'s>, mut out: W) -> std::fmt::Result
     where
         W: std::fmt::Write,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //! let djot_input = "hello *world*!";
 //! let events = jotdown::Parser::new(djot_input);
 //! let mut html = String::new();
-//! jotdown::html::Renderer.push(events, &mut html);
+//! jotdown::html::Renderer::default().push(events, &mut html);
 //! assert_eq!(html, "<p>hello <strong>world</strong>!</p>\n");
 //! # }
 //! ```
@@ -41,7 +41,7 @@
 //!         e => e,
 //!     });
 //! let mut html = String::new();
-//! jotdown::html::Renderer.push(events, &mut html);
+//! jotdown::html::Renderer::default().push(events, &mut html);
 //! assert_eq!(html, "<p>a <a href=\"https://example.net\">link</a></p>\n");
 //! # }
 //! ```
@@ -71,6 +71,11 @@ type CowStr<'s> = std::borrow::Cow<'s, str>;
 ///
 /// The output can be written to either a [`std::fmt::Write`] or a [`std::io::Write`] object.
 ///
+/// An implementor needs to at least implement the [`Render::render_event`] function that renders a
+/// single event to the output. If anything needs to be rendered at the beginning or end of the
+/// output, the [`Render::render_prologue`] and [`Render::render_epilogue`] can be implemented as
+/// well.
+///
 /// # Examples
 ///
 /// Push to a [`String`] (implements [`std::fmt::Write`]):
@@ -79,7 +84,8 @@ type CowStr<'s> = std::borrow::Cow<'s, str>;
 /// # use jotdown::Render;
 /// # let events = std::iter::empty();
 /// let mut output = String::new();
-/// jotdown::html::Renderer.push(events, &mut output);
+/// let mut renderer = jotdown::html::Renderer::default();
+/// renderer.push(events, &mut output);
 /// ```
 ///
 /// Write to standard output with buffering ([`std::io::Stdout`] implements [`std::io::Write`]):
@@ -88,25 +94,57 @@ type CowStr<'s> = std::borrow::Cow<'s, str>;
 /// # use jotdown::Render;
 /// # let events = std::iter::empty();
 /// let mut out = std::io::BufWriter::new(std::io::stdout());
-/// jotdown::html::Renderer.write(events, &mut out).unwrap();
+/// let mut renderer = jotdown::html::Renderer::default();
+/// renderer.write(events, &mut out).unwrap();
 /// ```
 pub trait Render {
-    /// Push [`Event`]s to a unicode-accepting buffer or stream.
-    fn push<'s, I: Iterator<Item = Event<'s>>, W: fmt::Write>(
-        &self,
-        events: I,
-        out: W,
-    ) -> fmt::Result;
+    /// Render a single event.
+    fn render_event<'s, W>(&mut self, e: &Event<'s>, out: W) -> std::fmt::Result
+    where
+        W: std::fmt::Write;
+
+    /// Render something before any events have been provided.
+    ///
+    /// This does nothing by default, but an implementation may choose to prepend data at the
+    /// beginning of the output if needed.
+    fn render_prologue<W>(&mut self, _out: W) -> std::fmt::Result
+    where
+        W: std::fmt::Write,
+    {
+        Ok(())
+    }
+
+    /// Render something after all events have been provided.
+    ///
+    /// This does nothing by default, but an implementation may choose to append extra data at the
+    /// end of the output if needed.
+    fn render_epilogue<W>(&mut self, _out: W) -> std::fmt::Result
+    where
+        W: std::fmt::Write,
+    {
+        Ok(())
+    }
+
+    /// Push owned [`Event`]s to a unicode-accepting buffer or stream.
+    fn push<'s, I, W>(&mut self, mut events: I, mut out: W) -> fmt::Result
+    where
+        I: Iterator<Item = Event<'s>>,
+        W: fmt::Write,
+    {
+        self.render_prologue(&mut out)?;
+        events.try_for_each(|e| self.render_event(&e, &mut out))?;
+        self.render_epilogue(&mut out)
+    }
 
     /// Write [`Event`]s to a byte sink, encoded as UTF-8.
     ///
     /// NOTE: This performs many small writes, so IO writes should be buffered with e.g.
     /// [`std::io::BufWriter`].
-    fn write<'s, I: Iterator<Item = Event<'s>>, W: io::Write>(
-        &self,
-        events: I,
-        out: W,
-    ) -> io::Result<()> {
+    fn write<'s, I, W>(&mut self, events: I, out: W) -> io::Result<()>
+    where
+        I: Iterator<Item = Event<'s>>,
+        W: io::Write,
+    {
         struct Adapter<T: io::Write> {
             inner: T,
             error: io::Result<()>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,29 @@ pub use attr::{AttributeValue, AttributeValueParts, Attributes};
 
 type CowStr<'s> = std::borrow::Cow<'s, str>;
 
+/// A trait for rendering [`Event`]s to an output format.
+///
+/// The output can be written to either a [`std::fmt::Write`] or a [`std::io::Write`] object.
+///
+/// # Examples
+///
+/// Push to a [`String`] (implements [`std::fmt::Write`]):
+///
+/// ```
+/// # use jotdown::Render;
+/// # let events = std::iter::empty();
+/// let mut output = String::new();
+/// jotdown::html::Renderer.push(events, &mut output);
+/// ```
+///
+/// Write to standard output with buffering ([`std::io::Stdout`] implements [`std::io::Write`]):
+///
+/// ```
+/// # use jotdown::Render;
+/// # let events = std::iter::empty();
+/// let mut out = std::io::BufWriter::new(std::io::stdout());
+/// jotdown::html::Renderer.write(events, &mut out).unwrap();
+/// ```
 pub trait Render {
     /// Push [`Event`]s to a unicode-accepting buffer or stream.
     fn push<'s, I: Iterator<Item = Event<'s>>, W: fmt::Write>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,11 +68,11 @@ fn run() -> Result<(), std::io::Error> {
     };
 
     let parser = jotdown::Parser::new(&content);
-    let html = jotdown::html::Renderer;
+    let mut renderer = jotdown::html::Renderer::default();
 
     match app.output {
-        Some(path) => html.write(parser, File::create(path)?)?,
-        None => html.write(parser, BufWriter::new(std::io::stdout()))?,
+        Some(path) => renderer.write(parser, File::create(path)?)?,
+        None => renderer.write(parser, BufWriter::new(std::io::stdout()))?,
     }
 
     Ok(())

--- a/tests/afl/src/lib.rs
+++ b/tests/afl/src/lib.rs
@@ -19,7 +19,9 @@ pub fn html(data: &[u8]) {
         if !s.contains("=html") {
             let p = jotdown::Parser::new(s);
             let mut html = "<!DOCTYPE html>\n".to_string();
-            jotdown::html::Renderer.push(p, &mut html).unwrap();
+            jotdown::html::Renderer::default()
+                .push(p, &mut html)
+                .unwrap();
             validate_html(&html);
         }
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -14,7 +14,9 @@ macro_rules! suite_test {
         let expected = $expected;
         let p = jotdown::Parser::new(src);
         let mut actual = String::new();
-        jotdown::html::Renderer.push(p, &mut actual).unwrap();
+        jotdown::html::Renderer::default()
+            .push(p, &mut actual)
+            .unwrap();
         assert_eq!(
             actual.trim(),
             expected.trim(),


### PR DESCRIPTION
addressing #24

#### benchmarks

both criterion and iai seem to agree there is some loss in performance. note that iai is parse + render and criterion is just the html rendering.
```
commit                                                          Mevents/s (criterion)   total estimated cycles (iai)
7063b9592 html: avoid peek of next event                        35.068 -14.193%         8331258 (+0.842470%)
38e9574df html: rm FilteredEvents                               37.792 +7.6143%         8341417 (+0.121938%)
ecaea39a4 html: rm events/out from Writer                       37.988 +0.5571%         8331315 (-0.121107%)
245a6a1fe html: extract Writer::render_{event, epilogue}        37.864 +0.7191%         8445378 (+1.369088%)
08800374d mv push/write examples from html to Render trait      37.826 -0.8853%         8445378 (No change)
4b73c19e1 lib: add Render::render_{event, prologue, epilogue}   37.023 -1.2867%         8448659 (+0.038850%)
5be2de71a lib: add Render::{push, write}_ref                    37.049 -0.2755%         8448583 (-0.000900%)
```
it seems like the avoid peek commit is the biggest problem. I'm not entirely sure why but I guess it is because we add some checks in the render loop:

```diff
     fn write(&mut self) -> std::fmt::Result {
         while let Some(e) = self.events.next() {
+            let prev_paragraph = self.prev_paragraph;
+            self.prev_paragraph = matches!(&e, Event::End(Container::Paragraph));
+            if prev_paragraph
+                && self.footnote_number.is_some()
+                && !matches!(&e, Event::End(Container::Footnote { .. }))
+            {
+                // no need to add href before para close
+                self.out.write_str("</p>")?;
+            }
             match e {
                 Event::Start(c, attrs) => {
```
maybe there is a better way to do it?