### PR TITLE
Emit link definitions and footnotes as they are encountered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ check:
 suite:
 	git submodule update --init modules/djot.js
 	for f in $$(find modules/djot.js/test -name '*.test' | xargs basename -a); do \
-		ln -fs ../../modules/djot.js/test/$$f tests/suite/$$f; \
+		ln -fs ../../modules/djot.js/test/$$f tests/suite/djot_js_$$f; \
 	done
 	(cd tests/suite && make)
 	cargo test --features suite suite::

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ afl_tmin:
 clean:
 	cargo clean
 	git submodule deinit -f --all
-	rm -f tests/suite/*.test
+	find tests -type l -path 'tests/suite/*.test' -print0 | xargs -0 rm -f
 	(cd tests/suite && make clean)
 	rm -f tests/bench/*.dj
 	(cd tests/bench && make clean)

--- a/bench/input/block_footnotes.dj
+++ b/bench/input/block_footnotes.dj
@@ -1,0 +1,24 @@
+[^abc]: footnotes may appear before
+
+Some[^a] paragraph[^b] with[^c] a[^d] lot[^e] of[^f] footnotes[^g].
+
+[^a]: A typical footnote may have a single paragraph.
+[^b]: A typical footnote may have a single paragraph.
+[^c]: A typical footnote may have a single paragraph.
+[^d]: A typical footnote may have a single paragraph.
+[^e]: A typical footnote may have a single paragraph.
+[^f]: A typical footnote may have a single paragraph.
+[^g]: Footnotes may also be
+
+    - long and,
+    - contain multiple block elements.
+
+    such as
+
+    > blockquotes.
+
+Footnote [^labels may be long but not multi line]
+
+[^labels may be long but not multi line]: longer than the footnote..
+
+the reference[^abc] to it.

--- a/src/html.rs
+++ b/src/html.rs
@@ -15,28 +15,21 @@ enum Raw {
     Other,
 }
 
+impl Default for Raw {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Default)]
 pub struct Renderer {
     raw: Raw,
     img_alt_text: usize,
     list_tightness: Vec<bool>,
     encountered_footnote: bool,
     footnote_number: Option<std::num::NonZeroUsize>,
-    first_line: bool,
+    not_first_line: bool,
     close_para: bool,
-}
-
-impl Default for Renderer {
-    fn default() -> Self {
-        Self {
-            raw: Raw::None,
-            img_alt_text: 0,
-            list_tightness: Vec::new(),
-            encountered_footnote: false,
-            footnote_number: None,
-            first_line: true,
-            close_para: false,
-        }
-    }
 }
 
 impl Render for Renderer {
@@ -59,7 +52,7 @@ impl Render for Renderer {
 
         match e {
             Event::Start(c, attrs) => {
-                if c.is_block() && !self.first_line {
+                if c.is_block() && self.not_first_line {
                     out.write_char('\n')?;
                 }
                 if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
@@ -389,7 +382,7 @@ impl Render for Renderer {
                 out.write_str(">")?;
             }
         }
-        self.first_line = false;
+        self.not_first_line = true;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,7 +200,7 @@ pub enum Event<'s> {
     /// A string object, text only.
     Str(CowStr<'s>),
     /// A footnote reference.
-    FootnoteReference(&'s str, usize),
+    FootnoteReference(&'s str),
     /// A symbol, by default rendered literally but may be treated specially.
     Symbol(CowStr<'s>),
     /// Left single quotation mark.
@@ -253,7 +253,7 @@ pub enum Container<'s> {
     /// Details describing a term within a description list.
     DescriptionDetails,
     /// A footnote definition.
-    Footnote { tag: &'s str, number: usize },
+    Footnote { label: &'s str },
     /// A table element.
     Table,
     /// A row element of a table.
@@ -560,15 +560,6 @@ pub struct Parser<'s> {
     /// Currently within a verbatim code block.
     verbatim: bool,
 
-    /// Footnote references in the order they were encountered, without duplicates.
-    footnote_references: Vec<&'s str>,
-    /// Cache of footnotes to emit at the end.
-    footnotes: Map<&'s str, block::Tree>,
-    /// Next or current footnote being parsed and emitted.
-    footnote_index: usize,
-    /// Currently within a footnote.
-    footnote_active: bool,
-
     /// Inline parser.
     inline_parser: inline::Parser<'s>,
 }
@@ -746,10 +737,6 @@ impl<'s> Parser<'s> {
             block_attributes: Attributes::new(),
             table_head_row: false,
             verbatim: false,
-            footnote_references: Vec::new(),
-            footnotes: Map::new(),
-            footnote_index: 0,
-            footnote_active: false,
             inline_parser,
         }
     }
@@ -838,19 +825,7 @@ impl<'s> Parser<'s> {
                 }
                 inline::EventKind::Atom(a) => match a {
                     inline::Atom::FootnoteReference => {
-                        let tag = inline.span.of(self.src);
-                        let number = self
-                            .footnote_references
-                            .iter()
-                            .position(|t| *t == tag)
-                            .map_or_else(
-                                || {
-                                    self.footnote_references.push(tag);
-                                    self.footnote_references.len()
-                                },
-                                |i| i + 1,
-                            );
-                        Event::FootnoteReference(inline.span.of(self.src), number)
+                        Event::FootnoteReference(inline.span.of(self.src))
                     }
                     inline::Atom::Symbol => Event::Symbol(inline.span.of(self.src).into()),
                     inline::Atom::Quote { ty, left } => match (ty, left) {
@@ -932,12 +907,7 @@ impl<'s> Parser<'s> {
                             block::Container::Div { .. } => Container::Div {
                                 class: (!ev.span.is_empty()).then(|| content),
                             },
-                            block::Container::Footnote => {
-                                debug_assert!(enter);
-                                self.footnotes.insert(content, self.tree.take_branch());
-                                self.block_attributes = Attributes::new();
-                                continue;
-                            }
+                            block::Container::Footnote => Container::Footnote { label: content },
                             block::Container::List(block::ListKind { ty, tight }) => {
                                 if matches!(ty, block::ListType::Description) {
                                     Container::DescriptionList
@@ -1004,43 +974,13 @@ impl<'s> Parser<'s> {
         }
         None
     }
-
-    fn footnote(&mut self) -> Option<Event<'s>> {
-        if self.footnote_active {
-            let tag = self.footnote_references.get(self.footnote_index).unwrap();
-            self.footnote_index += 1;
-            self.footnote_active = false;
-            Some(Event::End(Container::Footnote {
-                tag,
-                number: self.footnote_index,
-            }))
-        } else if let Some(tag) = self.footnote_references.get(self.footnote_index) {
-            self.tree = self
-                .footnotes
-                .remove(tag)
-                .unwrap_or_else(block::Tree::empty);
-            self.footnote_active = true;
-
-            Some(Event::Start(
-                Container::Footnote {
-                    tag,
-                    number: self.footnote_index + 1,
-                },
-                Attributes::new(),
-            ))
-        } else {
-            None
-        }
-    }
 }
 
 impl<'s> Iterator for Parser<'s> {
     type Item = Event<'s>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inline()
-            .or_else(|| self.block())
-            .or_else(|| self.footnote())
+        self.inline().or_else(|| self.block())
     }
 }
 
@@ -1554,43 +1494,10 @@ mod test {
         test_parse!(
             "[^a][^b][^c]",
             Start(Paragraph, Attributes::new()),
-            FootnoteReference("a", 1),
-            FootnoteReference("b", 2),
-            FootnoteReference("c", 3),
+            FootnoteReference("a"),
+            FootnoteReference("b"),
+            FootnoteReference("c"),
             End(Paragraph),
-            Start(
-                Footnote {
-                    tag: "a",
-                    number: 1
-                },
-                Attributes::new()
-            ),
-            End(Footnote {
-                tag: "a",
-                number: 1
-            }),
-            Start(
-                Footnote {
-                    tag: "b",
-                    number: 2
-                },
-                Attributes::new()
-            ),
-            End(Footnote {
-                tag: "b",
-                number: 2
-            }),
-            Start(
-                Footnote {
-                    tag: "c",
-                    number: 3
-                },
-                Attributes::new()
-            ),
-            End(Footnote {
-                tag: "c",
-                number: 3
-            }),
         );
     }
 
@@ -1599,23 +1506,14 @@ mod test {
         test_parse!(
             "[^a]\n\n[^a]: a\n",
             Start(Paragraph, Attributes::new()),
-            FootnoteReference("a", 1),
+            FootnoteReference("a"),
             End(Paragraph),
             Blankline,
-            Start(
-                Footnote {
-                    tag: "a",
-                    number: 1
-                },
-                Attributes::new()
-            ),
+            Start(Footnote { label: "a" }, Attributes::new()),
             Start(Paragraph, Attributes::new()),
             Str("a".into()),
             End(Paragraph),
-            End(Footnote {
-                tag: "a",
-                number: 1
-            }),
+            End(Footnote { label: "a" }),
         );
     }
 
@@ -1630,16 +1528,10 @@ mod test {
                 " def", //
             ),
             Start(Paragraph, Attributes::new()),
-            FootnoteReference("a", 1),
+            FootnoteReference("a"),
             End(Paragraph),
             Blankline,
-            Start(
-                Footnote {
-                    tag: "a",
-                    number: 1
-                },
-                Attributes::new()
-            ),
+            Start(Footnote { label: "a" }, Attributes::new()),
             Start(Paragraph, Attributes::new()),
             Str("abc".into()),
             End(Paragraph),
@@ -1647,10 +1539,7 @@ mod test {
             Start(Paragraph, Attributes::new()),
             Str("def".into()),
             End(Paragraph),
-            End(Footnote {
-                tag: "a",
-                number: 1
-            }),
+            End(Footnote { label: "a" }),
         );
     }
 
@@ -1664,26 +1553,17 @@ mod test {
                 "para\n", //
             ),
             Start(Paragraph, Attributes::new()),
-            FootnoteReference("a", 1),
+            FootnoteReference("a"),
             End(Paragraph),
             Blankline,
-            Start(Paragraph, Attributes::new()),
-            Str("para".into()),
-            End(Paragraph),
-            Start(
-                Footnote {
-                    tag: "a",
-                    number: 1
-                },
-                Attributes::new()
-            ),
+            Start(Footnote { label: "a" }, Attributes::new()),
             Start(Paragraph, Attributes::new()),
             Str("note".into()),
             End(Paragraph),
-            End(Footnote {
-                tag: "a",
-                number: 1
-            }),
+            End(Footnote { label: "a" }),
+            Start(Paragraph, Attributes::new()),
+            Str("para".into()),
+            End(Paragraph),
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,6 @@ type CowStr<'s> = std::borrow::Cow<'s, str>;
 /// If ownership of the [`Event`]s cannot be given to the renderer, use [`Render::push_borrowed`]
 /// or [`Render::write_borrowed`].
 ///
-/// An implementor needs to at least implement the [`Render::render_event`] function that renders a
-/// single event to the output. If anything needs to be rendered at the beginning or end of the
-/// output, the [`Render::render_prologue`] and [`Render::render_epilogue`] can be implemented as
-/// well.
-///
 /// # Examples
 ///
 /// Push to a [`String`] (implements [`std::fmt::Write`]):
@@ -88,7 +83,7 @@ type CowStr<'s> = std::borrow::Cow<'s, str>;
 /// # use jotdown::Render;
 /// # let events = std::iter::empty();
 /// let mut output = String::new();
-/// let mut renderer = jotdown::html::Renderer::default();
+/// let renderer = jotdown::html::Renderer::default();
 /// renderer.push(events, &mut output);
 /// ```
 ///
@@ -98,53 +93,21 @@ type CowStr<'s> = std::borrow::Cow<'s, str>;
 /// # use jotdown::Render;
 /// # let events = std::iter::empty();
 /// let mut out = std::io::BufWriter::new(std::io::stdout());
-/// let mut renderer = jotdown::html::Renderer::default();
+/// let renderer = jotdown::html::Renderer::default();
 /// renderer.write(events, &mut out).unwrap();
 /// ```
 pub trait Render {
-    /// Render a single event.
-    fn render_event<'s, W>(&mut self, e: &Event<'s>, out: W) -> std::fmt::Result
-    where
-        W: std::fmt::Write;
-
-    /// Render something before any events have been provided.
-    ///
-    /// This does nothing by default, but an implementation may choose to prepend data at the
-    /// beginning of the output if needed.
-    fn render_prologue<W>(&mut self, _out: W) -> std::fmt::Result
-    where
-        W: std::fmt::Write,
-    {
-        Ok(())
-    }
-
-    /// Render something after all events have been provided.
-    ///
-    /// This does nothing by default, but an implementation may choose to append extra data at the
-    /// end of the output if needed.
-    fn render_epilogue<W>(&mut self, _out: W) -> std::fmt::Result
-    where
-        W: std::fmt::Write,
-    {
-        Ok(())
-    }
-
     /// Push owned [`Event`]s to a unicode-accepting buffer or stream.
-    fn push<'s, I, W>(&mut self, mut events: I, mut out: W) -> fmt::Result
+    fn push<'s, I, W>(&self, events: I, out: W) -> fmt::Result
     where
         I: Iterator<Item = Event<'s>>,
-        W: fmt::Write,
-    {
-        self.render_prologue(&mut out)?;
-        events.try_for_each(|e| self.render_event(&e, &mut out))?;
-        self.render_epilogue(&mut out)
-    }
+        W: fmt::Write;
 
     /// Write owned [`Event`]s to a byte sink, encoded as UTF-8.
     ///
     /// NOTE: This performs many small writes, so IO writes should be buffered with e.g.
     /// [`std::io::BufWriter`].
-    fn write<'s, I, W>(&mut self, events: I, out: W) -> io::Result<()>
+    fn write<'s, I, W>(&self, events: I, out: W) -> io::Result<()>
     where
         I: Iterator<Item = Event<'s>>,
         W: io::Write,
@@ -169,25 +132,20 @@ pub trait Render {
     /// # use jotdown::Render;
     /// # let events: &[jotdown::Event] = &[];
     /// let mut output = String::new();
-    /// let mut renderer = jotdown::html::Renderer::default();
+    /// let renderer = jotdown::html::Renderer::default();
     /// renderer.push_borrowed(events.iter(), &mut output);
     /// ```
-    fn push_borrowed<'s, E, I, W>(&mut self, mut events: I, mut out: W) -> fmt::Result
+    fn push_borrowed<'s, E, I, W>(&self, events: I, out: W) -> fmt::Result
     where
         E: AsRef<Event<'s>>,
         I: Iterator<Item = E>,
-        W: fmt::Write,
-    {
-        self.render_prologue(&mut out)?;
-        events.try_for_each(|e| self.render_event(e.as_ref(), &mut out))?;
-        self.render_epilogue(&mut out)
-    }
+        W: fmt::Write;
 
     /// Write borrowed [`Event`]s to a byte sink, encoded as UTF-8.
     ///
     /// NOTE: This performs many small writes, so IO writes should be buffered with e.g.
     /// [`std::io::BufWriter`].
-    fn write_borrowed<'s, E, I, W>(&mut self, events: I, out: W) -> io::Result<()>
+    fn write_borrowed<'s, E, I, W>(&self, events: I, out: W) -> io::Result<()>
     where
         E: AsRef<Event<'s>>,
         I: Iterator<Item = E>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn run() -> Result<(), std::io::Error> {
     };
 
     let parser = jotdown::Parser::new(&content);
-    let mut renderer = jotdown::html::Renderer::default();
+    let renderer = jotdown::html::Renderer::default();
 
     match app.output {
         Some(path) => renderer.write(parser, File::create(path)?)?,

--- a/tests/suite/Makefile
+++ b/tests/suite/Makefile
@@ -5,9 +5,9 @@
 TEST=$(shell find . -name '*.test' | sort)
 TEST_RS=${TEST:.test=.rs}
 
-BLACKLIST += filters # lua filters not implemented
-BLACKLIST += symb # uses ast
-BLACKLIST += sourcepos # not parsable
+BLACKLIST += djot_js_filters # lua filters not implemented
+BLACKLIST += djot_js_symb # uses ast
+BLACKLIST += djot_js_sourcepos # not parsable
 
 .PHONY: suite
 suite: mod.rs

--- a/tests/suite/footnotes.test
+++ b/tests/suite/footnotes.test
@@ -1,0 +1,58 @@
+Footnote references may appear within a footnote.
+
+```
+[^a]
+
+[^a]: a[^b][^c]
+[^b]: b
+.
+<p><a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes">
+<hr>
+<ol>
+<li id="fn1">
+<p>a<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a><a id="fnref3" href="#fn3" role="doc-noteref"><sup>3</sup></a><a href="#fnref1" role="doc-backlink">↩︎︎</a></p>
+</li>
+<li id="fn2">
+<p>b<a href="#fnref2" role="doc-backlink">↩︎︎</a></p>
+</li>
+<li id="fn3">
+<p><a href="#fnref3" role="doc-backlink">↩︎︎</a></p>
+</li>
+</ol>
+</section>
+```
+
+Footnote references in unreferenced footnotes are ignored.
+
+```
+para
+
+[^a]: a[^b][^c]
+[^b]: b
+.
+<p>para</p>
+```
+
+Footnotes may appear within footnotes.
+
+```
+[^b]
+[^a]
+
+[^a]: [^b]: inner
+.
+<p><a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a>
+<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a></p>
+<section role="doc-endnotes">
+<hr>
+<ol>
+<li id="fn1">
+<p>inner<a href="#fnref1" role="doc-backlink">↩︎︎</a></p>
+</li>
+<li id="fn2">
+<p><a href="#fnref2" role="doc-backlink">↩︎︎</a></p>
+</li>
+</ol>
+</section>
+```


### PR DESCRIPTION
- #14, let renderer filter them out.
- #31, let renderer collect them to render them at the end.

This is in order to move towards a more 1:1 lossless event stream in order to support more use cases and allow parsing to be performed in a single pass.

## Benchmarks

Rendering has become slower while the parsing has become faster, so I would expect a small performance increase in the general case (e.g. readme). It seems to hold, except for a preparatory commit (7947478) with no behavioral change which seems to have a noticable performance regression on my Zen 3 computer.. Not really sure what is causing it, iai expects slight performance increase and the exact same functions have been inlined before and after. My other computer has unchanged performance for that commit.

#### full/readme

Zen 3 (desktop)
```
commit                                                                cycles (iai)           throughput (MB/s)
9dcbc7c bench: add block_footnotes benchmark                          6907791                70.561
176c3ac lib: emit LinkDefinition event                                6987887 (+1.159502%)   69.241
7947478 Revert "lib: add Render::render_{event, prologue, epilogue}"  6965218 (-0.324404%)   64.710
885d5c4 lib: emit footnotes as they are encountered                   6886898 (-1.124444%)   65.965
```

Kaby lake (laptop)
```
commit                                                                cycles (iai)           throughput (MB/s)
9dcbc7c bench: add block_footnotes benchmark                          7386107                44.129
176c3ac lib: emit LinkDefinition event                                7438337 (+0.707138%)   43.934
7947478 Revert "lib: add Render::render_{event, prologue, epilogue}"  7437609 (-0.009787%)   43.991
885d5c4 lib: emit footnotes as they are encountered                   7331649 (-1.424651%)   44.120
```

#### full/block_footnotes

I added a benchmark with footnotes because there isn't any at all in the current benchmarks. Footnotes have become slower but they are rare so I don't think it is a problem.

Zen 3 (desktop)
```
commit                                                                cycles (iai)           throughput (MB/s)
9dcbc7c bench: add block_footnotes benchmark                          6907791                49.528
176c3ac lib: emit LinkDefinition event                                6987887 (+1.159502%)   49.434
7947478 Revert "lib: add Render::render_{event, prologue, epilogue}"  6965218 (-0.324404%)   47.075
885d5c4 lib: emit footnotes as they are encountered                   6886898 (-1.124444%)   44.383
```

Coffee lake (laptop)
```
commit                                                                cycles (iai)           throughput (MB/s)
9dcbc7c bench: add block_footnotes benchmark                          7386107                32.847
176c3ac lib: emit LinkDefinition event                                7438337 (+0.707138%)   32.307
7947478 Revert "lib: add Render::render_{event, prologue, epilogue}"  7437609 (-0.009787%)   32.437
885d5c4 lib: emit footnotes as they are encountered                   7331649 (-1.424651%)   30.540
```