### PR TITLE
(&(mut ))Attributes::into_iter

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -185,7 +185,7 @@ impl<'s> Writer<'s> {
                     Container::LinkDefinition { .. } => return Ok(()),
                 }
 
-                for (a, v) in attrs.iter().filter(|(a, _)| *a != "class") {
+                for (a, v) in attrs.into_iter().filter(|(a, _)| *a != "class") {
                     write!(out, r#" {}=""#, a)?;
                     v.parts().try_for_each(|part| write_attr(part, &mut out))?;
                     out.write_char('"')?;
@@ -198,14 +198,14 @@ impl<'s> Writer<'s> {
                 }
                 | Container::Section { id } = &c
                 {
-                    if !attrs.iter().any(|(a, _)| a == "id") {
+                    if !attrs.into_iter().any(|(a, _)| a == "id") {
                         out.write_str(r#" id=""#)?;
                         write_attr(id, &mut out)?;
                         out.write_char('"')?;
                     }
                 }
 
-                if attrs.iter().any(|(a, _)| a == "class")
+                if attrs.into_iter().any(|(a, _)| a == "class")
                     || matches!(
                         c,
                         Container::Div { class } if !class.is_empty())
@@ -231,7 +231,7 @@ impl<'s> Writer<'s> {
                         out.write_str(cls)?;
                     }
                     for cls in attrs
-                        .iter()
+                        .into_iter()
                         .filter(|(a, _)| a == &"class")
                         .map(|(_, cls)| cls)
                     {
@@ -392,7 +392,7 @@ impl<'s> Writer<'s> {
                     out.write_char('\n')?;
                 }
                 out.write_str("<hr")?;
-                for (a, v) in attrs.iter() {
+                for (a, v) in attrs {
                     write!(out, r#" {}=""#, a)?;
                     v.parts().try_for_each(|part| write_attr(part, &mut out))?;
                     out.write_char('"')?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ mod lex;
 
 pub use attr::{
     AttributeValue, AttributeValueParts, Attributes, AttributesIntoIter, AttributesIter,
+    AttributesIterMut,
 };
 
 type CowStr<'s> = std::borrow::Cow<'s, str>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,9 @@ mod block;
 mod inline;
 mod lex;
 
-pub use attr::{AttributeValue, AttributeValueParts, Attributes, AttributesIntoIter};
+pub use attr::{
+    AttributeValue, AttributeValueParts, Attributes, AttributesIntoIter, AttributesIter,
+};
 
 type CowStr<'s> = std::borrow::Cow<'s, str>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ mod block;
 mod inline;
 mod lex;
 
-pub use attr::{AttributeValue, AttributeValueParts, Attributes};
+pub use attr::{AttributeValue, AttributeValueParts, Attributes, AttributesIntoIter};
 
 type CowStr<'s> = std::borrow::Cow<'s, str>;
 


### PR DESCRIPTION
See #33 .

~~I'm struggling with the lifetimes for `AttrIterMut`, as mutably borrowing from the attribute vec creates a new lifetime I'm finding hard to express in the impl; but this is at least as good as the current implementation.~~