### PR TITLE
Resolve roman/alpha numeral ambiguity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1083,25 +1083,21 @@ impl<'s> Parser<'s> {
                             block::Container::Blockquote => Container::Blockquote,
                             block::Container::Div { class } => Container::Div { class },
                             block::Container::Footnote { label } => Container::Footnote { label },
-                            block::Container::List {
-                                kind: block::ListKind { ty, tight },
-                                marker,
-                            } => {
+                            block::Container::List { ty, tight } => {
                                 if matches!(ty, block::ListType::Description) {
                                     Container::DescriptionList
                                 } else {
                                     let kind = match ty {
                                         block::ListType::Unordered(..) => ListKind::Unordered,
                                         block::ListType::Task => ListKind::Task,
-                                        block::ListType::Ordered(numbering, style) => {
-                                            let start =
-                                                numbering.parse_number(style.number(marker)).max(1);
-                                            ListKind::Ordered {
-                                                numbering,
-                                                style,
-                                                start,
-                                            }
-                                        }
+                                        block::ListType::Ordered(
+                                            block::ListNumber { numbering, value },
+                                            style,
+                                        ) => ListKind::Ordered {
+                                            numbering,
+                                            style,
+                                            start: value,
+                                        },
                                         block::ListType::Description => unreachable!(),
                                     };
                                     Container::List { kind, tight }

--- a/tests/html-ut/skip
+++ b/tests/html-ut/skip
@@ -7,6 +7,4 @@ e1f5b5e:untrimmed whitespace before linebreak
 07888f3:div close within raw block
 8423412:heading id conflict with existing id
 c0a3dec:escape in url
-61876cf:roman alpha ambiguity
-f31b357:roman alpha ambiguity
 642d380:table end in verbatim inline

--- a/tests/html-ut/ut/lists.test
+++ b/tests/html-ut/ut/lists.test
@@ -18,3 +18,31 @@ word. Continuing paragraph.
 .
 <p>word. Continuing paragraph.</p>
 ```
+
+Prioritize current type when ambigiuous.
+
+```
+A) first
+B) second
+C) third
+D) fourth
+E) fifth
+.
+<ol type="A">
+<li>
+first
+</li>
+<li>
+second
+</li>
+<li>
+third
+</li>
+<li>
+fourth
+</li>
+<li>
+fifth
+</li>
+</ol>
+```


### PR DESCRIPTION
fixes #46

slightly decreased performance on list parsing, but negligible for typical documents.

```
commit                                                block_list_nested  block_list_flat  readme [MB/s]
ccff83ce9 lib: clippy fixes                           23.229             31.966           107.16
9dde8c517 lib: parse list numbers during block parse  22.512             30.717           105.77
251c5d61d block: resolve roman/alpha ambiguity        22.129             30.763           106.44
```