### PR TITLE
attrs: preserve duplicates and comments

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -694,6 +694,59 @@ mod test {
         assert_eq!(super::valid("{.abc.}"), 0);
     }
 
+    #[test]
+    fn get_value_named() {
+        assert_eq!(
+            Attributes::try_from("{x=a}").unwrap().get("x"),
+            Some(&"a".into()),
+        );
+        assert_eq!(
+            Attributes::try_from("{x=a x=b}").unwrap().get("x"),
+            Some(&"b".into()),
+        );
+    }
+
+    #[test]
+    fn get_value_id() {
+        assert_eq!(
+            Attributes::try_from("{#a}").unwrap().get("id"),
+            Some(&"a".into()),
+        );
+        assert_eq!(
+            Attributes::try_from("{#a #b}").unwrap().get("id"),
+            Some(&"b".into()),
+        );
+        assert_eq!(
+            Attributes::try_from("{#a id=b}").unwrap().get("id"),
+            Some(&"b".into()),
+        );
+        assert_eq!(
+            Attributes::try_from("{id=a #b}").unwrap().get("id"),
+            Some(&"b".into()),
+        );
+    }
+
+    #[test]
+    fn get_value_class() {
+        assert_eq!(
+            Attributes::try_from("{.a #a .b #b .c}")
+                .unwrap()
+                .get("class"),
+            Some(&"a b c".into()),
+        );
+        assert_eq!(Attributes::try_from("{#a}").unwrap().get("class"), None,);
+        assert_eq!(
+            Attributes::try_from("{.a}").unwrap().get("class"),
+            Some(&"a".into()),
+        );
+        assert_eq!(
+            Attributes::try_from("{.a #a class=b #b .c}")
+                .unwrap()
+                .get("class"),
+            Some(&"a  b c".into()), // bug: extra space?
+        );
+    }
+
     fn make_attrs<'a>(v: Vec<(&'a str, &'a str)>) -> Attributes<'a> {
         v.into_iter().collect()
     }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -24,6 +24,8 @@ pub(crate) fn valid(src: &str) -> usize {
 
 /// Stores an attribute value that supports backslash escapes of ASCII punctuation upon displaying,
 /// without allocating.
+///
+/// Each value is paired together with an [`AttributeKind`] in order to form an element.
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct AttributeValue<'s> {
     raw: CowStr<'s>,
@@ -120,9 +122,72 @@ impl<'s> Iterator for AttributeValueParts<'s> {
     }
 }
 
-/// A collection of attributes, i.e. a key-value map.
+/// The kind of an element within an attribute set.
+///
+/// Each kind is paired together with an [`AttributeValue`] to form an element.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AttributeKind<'s> {
+    /// A class element, e.g. `.a`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let mut a = Attributes::try_from("{.a}").unwrap().into_iter();
+    /// assert_eq!(a.next(), Some((AttributeKind::Class, "a".into())));
+    /// assert_eq!(a.next(), None);
+    /// ```
+    Class,
+    /// An id element, e.g. `#a`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let mut a = Attributes::try_from("{#a}").unwrap().into_iter();
+    /// assert_eq!(a.next(), Some((AttributeKind::Id, "a".into())));
+    /// assert_eq!(a.next(), None);
+    /// ```
+    Id,
+    /// A key-value pair element, e.g. `key=value`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let mut a = Attributes::try_from(r#"{key=value id="a"}"#)
+    ///     .unwrap()
+    ///     .into_iter();
+    /// assert_eq!(
+    ///     a.next(),
+    ///     Some((AttributeKind::Pair { key: "key" }, "value".into())),
+    /// );
+    /// assert_eq!(
+    ///     a.next(),
+    ///     Some((AttributeKind::Pair { key: "id" }, "a".into())),
+    /// );
+    /// assert_eq!(a.next(), None);
+    /// ```
+    Pair { key: &'s str },
+}
+
+impl<'s> AttributeKind<'s> {
+    /// Returns the element's key.
+    #[must_use]
+    pub fn key(&self) -> &'s str {
+        match self {
+            AttributeKind::Class => "class",
+            AttributeKind::Id => "id",
+            AttributeKind::Pair { key: k } => k,
+        }
+    }
+}
+
+/// A set of attributes, with order, duplicates and comments preserved.
 #[derive(Clone, PartialEq, Eq, Default)]
-pub struct Attributes<'s>(Vec<(&'s str, AttributeValue<'s>)>);
+pub struct Attributes<'s>(Vec<AttributeElem<'s>>);
+
+type AttributeElem<'s> = (AttributeKind<'s>, AttributeValue<'s>);
 
 impl<'s> Attributes<'s> {
     /// Create an empty collection.
@@ -145,41 +210,13 @@ impl<'s> Attributes<'s> {
     }
 
     /// Combine all attributes from both objects, prioritizing self on conflicts.
-    pub(crate) fn union(&mut self, other: Self) {
-        for (key, val) in other.0 {
-            if key == "class" || !self.0.iter().any(|(k, _)| *k == key) {
-                self.0.push((key, val));
-            }
-        }
+    pub(crate) fn concat(&mut self, mut other: Self) {
+        other.0.append(&mut self.0);
+        self.0 = other.0;
     }
 
-    /// Insert an attribute. If the attribute already exists, the previous value will be
-    /// overwritten, unless it is a "class" attribute. In that case the provided value will be
-    /// appended to the existing value.
-    pub fn insert(&mut self, key: &'s str, val: AttributeValue<'s>) {
-        self.insert_pos(key, val);
-    }
-
-    // duplicate of insert but returns position of inserted value
-    fn insert_pos(&mut self, key: &'s str, val: AttributeValue<'s>) -> usize {
-        if let Some(i) = self.0.iter().position(|(k, _)| *k == key) {
-            let prev = &mut self.0[i].1;
-            if key == "class" {
-                match val.raw {
-                    CowStr::Borrowed(s) => prev.extend(s),
-                    CowStr::Owned(s) => {
-                        *prev = format!("{} {}", prev, s).into();
-                    }
-                }
-            } else {
-                *prev = val;
-            }
-            i
-        } else {
-            let i = self.0.len();
-            self.0.push((key, val));
-            i
-        }
+    pub fn push(&mut self, key: AttributeKind<'s>, val: AttributeValue<'s>) {
+        self.0.push((key, val));
     }
 
     /// Returns true if the collection contains no attributes.
@@ -193,15 +230,65 @@ impl<'s> Attributes<'s> {
         self.0.len()
     }
 
-    /// Returns a reference to the value corresponding to the attribute key.
+    /// Returns whether the specified key exists in the set.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let a = Attributes::try_from("{x=y .a}").unwrap();
+    /// assert!(a.contains_key("x"));
+    /// assert!(!a.contains_key("y"));
+    /// assert!(a.contains_key("class"));
+    /// ```
     #[must_use]
-    pub fn get(&self, key: &str) -> Option<&AttributeValue> {
-        self.iter().find(|(k, _)| *k == key).map(|(_, v)| v)
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.0.iter().any(|(k, _)| k.key() == key)
     }
 
-    /// Returns a mutable reference to the value corresponding to the attribute key.
-    pub fn get_mut(&'s mut self, key: &str) -> Option<&mut AttributeValue> {
-        self.iter_mut().find(|(k, _)| *k == key).map(|(_, v)| v)
+    /// Returns the value corresponding to the provided attribute key.
+    ///
+    /// Note: A copy of the value is returned rather than a reference, due to class values
+    /// differing from its internal representation.
+    ///
+    /// # Examples
+    ///
+    /// For the "class" key, concatenate all class values:
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// assert_eq!(
+    ///     Attributes::try_from("{.a class=b}").unwrap().get_value("class"),
+    ///     Some("a b".into()),
+    /// );
+    /// ```
+    ///
+    /// For other keys, return the last set value:
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// assert_eq!(
+    ///     Attributes::try_from("{x=a x=b}").unwrap().get_value("x"),
+    ///     Some("b".into()),
+    /// );
+    /// ```
+    #[must_use]
+    pub fn get_value(&self, key: &str) -> Option<AttributeValue> {
+        if key == "class" && self.0.iter().filter(|(k, _)| k.key() == "class").count() > 1 {
+            let mut value = AttributeValue::new();
+            for (k, v) in &self.0 {
+                if k.key() == "class" {
+                    value.extend(&v.raw);
+                }
+            }
+            Some(value)
+        } else {
+            self.0
+                .iter()
+                .rfind(|(k, _)| k.key() == key)
+                .map(|(_, v)| v.clone())
+        }
     }
 
     /// Returns an iterator over references to the attribute keys and values in undefined order.
@@ -212,6 +299,48 @@ impl<'s> Attributes<'s> {
     /// Returns an iterator over mutable references to the attribute keys and values in undefined order.
     pub fn iter_mut<'i>(&'i mut self) -> AttributesIterMut<'i, 's> {
         self.into_iter()
+    }
+
+    /// Returns an iterator that only emits a single key-value pair per unique key, i.e. like they
+    /// appear in the rendered output.
+    ///
+    /// # Examples
+    ///
+    /// For "class" elements, values are concatenated:
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let a: Attributes = "{class=a .b}".try_into().unwrap();
+    /// let mut pairs = a.unique_pairs();
+    /// assert_eq!(pairs.next(), Some(("class", "a b".into())));
+    /// assert_eq!(pairs.next(), None);
+    /// ```
+    ///
+    /// For other keys, the last set value is used:
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let a: Attributes = "{id=a key=b #c key=d}".try_into().unwrap();
+    /// let mut pairs = a.unique_pairs();
+    /// assert_eq!(pairs.next(), Some(("id", "c".into())));
+    /// assert_eq!(pairs.next(), Some(("key", "d".into())));
+    /// assert_eq!(pairs.next(), None);
+    /// ```
+    ///
+    /// Comments are ignored:
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let a: Attributes = "{%cmt% #a}".try_into().unwrap();
+    /// let mut pairs = a.unique_pairs();
+    /// assert_eq!(pairs.next(), Some(("id", "a".into())));
+    /// ```
+    #[must_use]
+    pub fn unique_pairs<'a>(&'a self) -> AttributePairsIter<'a, 's> {
+        AttributePairsIter {
+            attrs: &self.0,
+            pos: 0,
+        }
     }
 }
 
@@ -234,18 +363,19 @@ impl<'s> TryFrom<&'s str> for Attributes<'s> {
     /// A single set of attributes can be parsed:
     ///
     /// ```
-    /// # use jotdown::Attributes;
+    /// # use jotdown::*;
     /// let mut a = Attributes::try_from("{.a}").unwrap().into_iter();
-    /// assert_eq!(a.next(), Some(("class", "a".into())));
+    /// assert_eq!(a.next(), Some((AttributeKind::Class, "a".into())));
     /// assert_eq!(a.next(), None);
     /// ```
     ///
     /// Multiple sets can be parsed if they immediately follow the each other:
     ///
     /// ```
-    /// # use jotdown::Attributes;
+    /// # use jotdown::*;
     /// let mut a = Attributes::try_from("{.a}{.b}").unwrap().into_iter();
-    /// assert_eq!(a.next(), Some(("class", "a b".into())));
+    /// assert_eq!(a.next(), Some((AttributeKind::Class, "a".into())));
+    /// assert_eq!(a.next(), Some((AttributeKind::Class, "b".into())));
     /// assert_eq!(a.next(), None);
     /// ```
     ///
@@ -265,8 +395,8 @@ impl<'s> TryFrom<&'s str> for Attributes<'s> {
 }
 
 #[cfg(test)]
-impl<'s> FromIterator<(&'s str, &'s str)> for Attributes<'s> {
-    fn from_iter<I: IntoIterator<Item = (&'s str, &'s str)>>(iter: I) -> Self {
+impl<'s> FromIterator<(AttributeKind<'s>, &'s str)> for Attributes<'s> {
+    fn from_iter<I: IntoIterator<Item = (AttributeKind<'s>, &'s str)>>(iter: I) -> Self {
         let attrs = iter
             .into_iter()
             .map(|(a, v)| (a, v.into()))
@@ -283,7 +413,7 @@ impl<'s> std::fmt::Debug for Attributes<'s> {
     /// ```
     /// # use jotdown::*;
     /// let a = r#"{#a .b id=c class=d key="val" %comment%}"#;
-    /// let b = r#"{id="c", class="b d", key="val"}"#;
+    /// let b = r#"{#a .b id="c" class="d" key="val"}"#;
     /// assert_eq!(format!("{:?}", Attributes::try_from(a).unwrap()), b);
     /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -291,20 +421,24 @@ impl<'s> std::fmt::Debug for Attributes<'s> {
         let mut first = true;
         for (k, v) in self {
             if !first {
-                write!(f, ", ")?;
+                write!(f, " ")?;
             }
             first = false;
-            write!(f, "{}=\"{}\"", k, v.raw)?;
+            match k {
+                AttributeKind::Class => write!(f, ".{}", v.raw)?,
+                AttributeKind::Id => write!(f, "#{}", v.raw)?,
+                AttributeKind::Pair { key } => write!(f, "{}=\"{}\"", key, v.raw)?,
+            }
         }
         write!(f, "}}")
     }
 }
 
 /// Iterator over [Attributes] key-value pairs, in arbitrary order.
-pub struct AttributesIntoIter<'s>(std::vec::IntoIter<(&'s str, AttributeValue<'s>)>);
+pub struct AttributesIntoIter<'s>(std::vec::IntoIter<AttributeElem<'s>>);
 
 impl<'s> Iterator for AttributesIntoIter<'s> {
-    type Item = (&'s str, AttributeValue<'s>);
+    type Item = AttributeElem<'s>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
@@ -316,7 +450,7 @@ impl<'s> Iterator for AttributesIntoIter<'s> {
 }
 
 impl<'s> IntoIterator for Attributes<'s> {
-    type Item = (&'s str, AttributeValue<'s>);
+    type Item = AttributeElem<'s>;
 
     type IntoIter = AttributesIntoIter<'s>;
 
@@ -326,10 +460,10 @@ impl<'s> IntoIterator for Attributes<'s> {
 }
 
 /// Iterator over references to [Attributes] key-value pairs, in arbitrary order.
-pub struct AttributesIter<'i, 's>(std::slice::Iter<'i, (&'s str, AttributeValue<'s>)>);
+pub struct AttributesIter<'i, 's>(std::slice::Iter<'i, AttributeElem<'s>>);
 
 impl<'i, 's> Iterator for AttributesIter<'i, 's> {
-    type Item = (&'s str, &'i AttributeValue<'s>);
+    type Item = (AttributeKind<'s>, &'i AttributeValue<'s>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(move |(k, v)| (*k, v))
@@ -341,7 +475,7 @@ impl<'i, 's> Iterator for AttributesIter<'i, 's> {
 }
 
 impl<'i, 's> IntoIterator for &'i Attributes<'s> {
-    type Item = (&'s str, &'i AttributeValue<'s>);
+    type Item = (AttributeKind<'s>, &'i AttributeValue<'s>);
 
     type IntoIter = AttributesIter<'i, 's>;
 
@@ -351,10 +485,10 @@ impl<'i, 's> IntoIterator for &'i Attributes<'s> {
 }
 
 /// Iterator over mutable references to [Attributes] key-value pairs, in arbitrary order.
-pub struct AttributesIterMut<'i, 's>(std::slice::IterMut<'i, (&'s str, AttributeValue<'s>)>);
+pub struct AttributesIterMut<'i, 's>(std::slice::IterMut<'i, AttributeElem<'s>>);
 
 impl<'i, 's> Iterator for AttributesIterMut<'i, 's> {
-    type Item = (&'s str, &'i mut AttributeValue<'s>);
+    type Item = (AttributeKind<'s>, &'i mut AttributeValue<'s>);
 
     fn next(&mut self) -> Option<Self::Item> {
         // this map splits &(&k, v) into (&&k, &v)
@@ -367,12 +501,54 @@ impl<'i, 's> Iterator for AttributesIterMut<'i, 's> {
 }
 
 impl<'i, 's> IntoIterator for &'i mut Attributes<'s> {
-    type Item = (&'s str, &'i mut AttributeValue<'s>);
+    type Item = (AttributeKind<'s>, &'i mut AttributeValue<'s>);
 
     type IntoIter = AttributesIterMut<'i, 's>;
 
     fn into_iter(self) -> Self::IntoIter {
         AttributesIterMut(self.0.iter_mut())
+    }
+}
+
+/// Iterator of unique attribute pairs.
+///
+/// See [`Attributes::unique_pairs`] for more information.
+pub struct AttributePairsIter<'a, 's> {
+    attrs: &'a [AttributeElem<'s>],
+    pos: usize,
+}
+
+impl<'a: 's, 's> Iterator for AttributePairsIter<'a, 's> {
+    type Item = (&'s str, AttributeValue<'s>);
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some((key, value)) = self.attrs[self.pos..].first() {
+            self.pos += 1;
+            let key = key.key();
+
+            if self.attrs[..self.pos - 1]
+                .iter()
+                .any(|(k, _)| k.key() == key)
+            {
+                continue; // already emitted when this key first encountered
+            }
+
+            if key == "class" {
+                let mut value = value.clone();
+                for (k, v) in &self.attrs[self.pos..] {
+                    if k.key() == "class" {
+                        value.extend(&v.raw);
+                    }
+                }
+                return Some((key, value));
+            }
+
+            if let Some((_, v)) = self.attrs[self.pos..].iter().rfind(|(k, _)| k.key() == key) {
+                return Some((key, v.clone())); // emit last value when key first encountered
+            }
+
+            return Some((key, value.clone()));
+        }
+        None
     }
 }
 
@@ -412,7 +588,6 @@ impl Validator {
 /// object.
 pub struct Parser<'s> {
     attrs: Attributes<'s>,
-    i_prev: usize,
     state: State,
 }
 
@@ -420,7 +595,6 @@ impl<'s> Parser<'s> {
     pub fn new(attrs: Attributes<'s>) -> Self {
         Self {
             attrs,
-            i_prev: usize::MAX,
             state: State::Start,
         }
     }
@@ -445,11 +619,14 @@ impl<'s> Parser<'s> {
                 let content = &input[pos_prev..pos];
                 pos_prev = pos;
                 match st {
-                    Class => self.attrs.insert("class", content.into()),
-                    Identifier => self.attrs.insert("id", content.into()),
-                    Key => self.i_prev = self.attrs.insert_pos(content, "".into()),
+                    Class => self.attrs.push(AttributeKind::Class, content.into()),
+                    Identifier => self.attrs.push(AttributeKind::Id, content.into()),
+                    Key => self
+                        .attrs
+                        .push(AttributeKind::Pair { key: content }, "".into()),
                     Value | ValueQuoted | ValueContinued => {
-                        self.attrs.0[self.i_prev]
+                        let last = self.attrs.len() - 1;
+                        self.attrs.0[last]
                             .1
                             .extend(&content[usize::from(matches!(st, ValueQuoted))..]);
                     }
@@ -545,43 +722,49 @@ pub fn is_name(c: u8) -> bool {
 
 #[cfg(test)]
 mod test {
+    use super::AttributeKind::*;
     use super::*;
 
     macro_rules! test_attr {
-        ($src:expr $(,$($av:expr),* $(,)?)?) => {
+        ($src:expr, [$($exp:expr),* $(,)?], [$($exp_uniq:expr),* $(,)?] $(,)?) => {
             #[allow(unused)]
             let mut attr = Attributes::try_from($src).unwrap();
-            let actual = attr.iter().collect::<Vec<_>>();
-            let expected = &[$($($av),*,)?];
-            for i in 0..actual.len() {
-                let actual_val = format!("{}", actual[i].1);
-                assert_eq!((actual[i].0, actual_val.as_str()), expected[i], "\n\n{}\n\n", $src);
-            }
+
+            let actual = attr.iter().map(|(k, v)| (k, v.to_string())).collect::<Vec<_>>();
+            let expected = &[$($exp),*].map(|(k, v): (_, &str)| (k, v.to_string()));
+            assert_eq!(actual, expected, "\n\n{}\n\n", $src);
+
+            let actual = attr.unique_pairs().map(|(k, v)| (k, v.to_string())).collect::<Vec<_>>();
+            let expected = &[$($exp_uniq),*].map(|(k, v): (_, &str)| (k, v.to_string()));
+            assert_eq!(actual, expected, "\n\n{}\n\n", $src);
         };
     }
 
     #[test]
     fn empty() {
-        test_attr!("{}");
+        test_attr!("{}", [], []);
     }
 
     #[test]
     fn class_id() {
         test_attr!(
             "{.some_class #some_id}",
-            ("class", "some_class"),
-            ("id", "some_id"),
+            [(Class, "some_class"), (Id, "some_id")],
+            [("class", "some_class"), ("id", "some_id")],
         );
-        test_attr!("{.a .b}", ("class", "a b"));
-        test_attr!("{#a #b}", ("id", "b"));
+        test_attr!("{.a .b}", [(Class, "a"), (Class, "b")], [("class", "a b")]);
+        test_attr!("{#a #b}", [(Id, "a"), (Id, "b")], [("id", "b")]);
     }
 
     #[test]
     fn value_unquoted() {
         test_attr!(
             "{attr0=val0 attr1=val1}",
-            ("attr0", "val0"),
-            ("attr1", "val1"),
+            [
+                (Pair { key: "attr0" }, "val0"),
+                (Pair { key: "attr1" }, "val1"),
+            ],
+            [("attr0", "val0"), ("attr1", "val1")],
         );
     }
 
@@ -589,32 +772,46 @@ mod test {
     fn value_quoted() {
         test_attr!(
             r#"{attr0="val0" attr1="val1"}"#,
-            ("attr0", "val0"),
-            ("attr1", "val1"),
+            [
+                (Pair { key: "attr0" }, "val0"),
+                (Pair { key: "attr1" }, "val1"),
+            ],
+            [("attr0", "val0"), ("attr1", "val1")],
         );
         test_attr!(
             r#"{#id .class style="color:red"}"#,
-            ("id", "id"),
-            ("class", "class"),
-            ("style", "color:red")
+            [
+                (Id, "id"),
+                (Class, "class"),
+                (Pair { key: "style" }, "color:red"),
+            ],
+            [("id", "id"), ("class", "class"), ("style", "color:red")]
         );
     }
 
     #[test]
     fn value_newline() {
-        test_attr!("{attr0=\"abc\ndef\"}", ("attr0", "abc def"));
+        test_attr!(
+            "{attr0=\"abc\ndef\"}",
+            [(Pair { key: "attr0" }, "abc def")],
+            [("attr0", "abc def")]
+        );
     }
 
     #[test]
     fn comment() {
-        test_attr!("{%}");
-        test_attr!("{%%}");
-        test_attr!("{ % abc % }");
-        test_attr!("{ .some_class % #some_id }", ("class", "some_class"));
+        test_attr!("{%}", [], []);
+        test_attr!("{%%}", [], []);
+        test_attr!("{ % abc % }", [], []);
+        test_attr!(
+            "{ .some_class % #some_id }",
+            [(Class, "some_class")],
+            [("class", "some_class")]
+        );
         test_attr!(
             "{ .some_class % abc % #some_id}",
-            ("class", "some_class"),
-            ("id", "some_id"),
+            [(Class, "some_class"), (Id, "some_id")],
+            [("class", "some_class"), ("id", "some_id")],
         );
     }
 
@@ -622,33 +819,46 @@ mod test {
     fn escape() {
         test_attr!(
             r#"{attr="with escaped \~ char"}"#,
-            ("attr", "with escaped ~ char")
+            [(Pair { key: "attr" }, "with escaped ~ char")],
+            [("attr", "with escaped ~ char")]
         );
         test_attr!(
             r#"{key="quotes \" should be escaped"}"#,
-            ("key", r#"quotes " should be escaped"#)
+            [(Pair { key: "key" }, r#"quotes " should be escaped"#)],
+            [("key", r#"quotes " should be escaped"#)]
         );
     }
 
     #[test]
     fn escape_backslash() {
-        test_attr!(r#"{attr="with\\backslash"}"#, ("attr", r"with\backslash"));
+        test_attr!(
+            r#"{attr="with\\backslash"}"#,
+            [(Pair { key: "attr" }, r"with\backslash")],
+            [("attr", r"with\backslash")]
+        );
         test_attr!(
             r#"{attr="with many backslashes\\\\"}"#,
-            ("attr", r"with many backslashes\\")
+            [(Pair { key: "attr" }, r"with many backslashes\\")],
+            [("attr", r"with many backslashes\\")]
         );
         test_attr!(
             r#"{attr="\\escaped backslash at start"}"#,
-            ("attr", r"\escaped backslash at start")
+            [(Pair { key: "attr" }, r"\escaped backslash at start")],
+            [("attr", r"\escaped backslash at start")]
         );
     }
 
     #[test]
     fn only_escape_punctuation() {
-        test_attr!(r#"{attr="do not \escape"}"#, ("attr", r"do not \escape"));
+        test_attr!(
+            r#"{attr="do not \escape"}"#,
+            [(Pair { key: "attr" }, r"do not \escape")],
+            [("attr", r"do not \escape")]
+        );
         test_attr!(
             r#"{attr="\backslash at the beginning"}"#,
-            ("attr", r"\backslash at the beginning")
+            [(Pair { key: "attr" }, r"\backslash at the beginning")],
+            [("attr", r"\backslash at the beginning")]
         );
     }
 
@@ -700,32 +910,32 @@ mod test {
     #[test]
     fn get_value_named() {
         assert_eq!(
-            Attributes::try_from("{x=a}").unwrap().get("x"),
-            Some(&"a".into()),
+            Attributes::try_from("{x=a}").unwrap().get_value("x"),
+            Some("a".into()),
         );
         assert_eq!(
-            Attributes::try_from("{x=a x=b}").unwrap().get("x"),
-            Some(&"b".into()),
+            Attributes::try_from("{x=a x=b}").unwrap().get_value("x"),
+            Some("b".into()),
         );
     }
 
     #[test]
     fn get_value_id() {
         assert_eq!(
-            Attributes::try_from("{#a}").unwrap().get("id"),
-            Some(&"a".into()),
+            Attributes::try_from("{#a}").unwrap().get_value("id"),
+            Some("a".into()),
         );
         assert_eq!(
-            Attributes::try_from("{#a #b}").unwrap().get("id"),
-            Some(&"b".into()),
+            Attributes::try_from("{#a #b}").unwrap().get_value("id"),
+            Some("b".into()),
         );
         assert_eq!(
-            Attributes::try_from("{#a id=b}").unwrap().get("id"),
-            Some(&"b".into()),
+            Attributes::try_from("{#a id=b}").unwrap().get_value("id"),
+            Some("b".into()),
         );
         assert_eq!(
-            Attributes::try_from("{id=a #b}").unwrap().get("id"),
-            Some(&"b".into()),
+            Attributes::try_from("{id=a #b}").unwrap().get_value("id"),
+            Some("b".into()),
         );
     }
 
@@ -734,58 +944,59 @@ mod test {
         assert_eq!(
             Attributes::try_from("{.a #a .b #b .c}")
                 .unwrap()
-                .get("class"),
-            Some(&"a b c".into()),
+                .get_value("class"),
+            Some("a b c".into()),
         );
-        assert_eq!(Attributes::try_from("{#a}").unwrap().get("class"), None,);
         assert_eq!(
-            Attributes::try_from("{.a}").unwrap().get("class"),
-            Some(&"a".into()),
+            Attributes::try_from("{#a}").unwrap().get_value("class"),
+            None,
+        );
+        assert_eq!(
+            Attributes::try_from("{.a}").unwrap().get_value("class"),
+            Some("a".into()),
         );
         assert_eq!(
             Attributes::try_from("{.a #a class=b #b .c}")
                 .unwrap()
-                .get("class"),
-            Some(&"a b c".into()),
+                .get_value("class"),
+            Some("a b c".into()),
         );
-    }
-
-    fn make_attrs<'a>(v: Vec<(&'a str, &'a str)>) -> Attributes<'a> {
-        v.into_iter().collect()
     }
 
     #[test]
     fn can_iter() {
-        let attrs = make_attrs(vec![("key1", "val1"), ("key2", "val2")]);
-        let as_vec = attrs.iter().collect::<Vec<_>>();
         assert_eq!(
-            as_vec,
+            Attributes::try_from("{key1=val1 key2=val2}")
+                .unwrap()
+                .iter()
+                .collect::<Vec<_>>(),
             vec![
-                ("key1", &AttributeValue::from("val1")),
-                ("key2", &AttributeValue::from("val2")),
+                (Pair { key: "key1" }, &AttributeValue::from("val1")),
+                (Pair { key: "key2" }, &AttributeValue::from("val2")),
             ]
         );
     }
 
     #[test]
     fn can_iter_mut() {
-        let mut attrs = make_attrs(vec![("key1", "val1"), ("key2", "val2")]);
-        let as_vec = attrs.iter_mut().collect::<Vec<_>>();
         assert_eq!(
-            as_vec,
+            Attributes::try_from("{key1=val1 key2=val2}")
+                .unwrap()
+                .iter_mut()
+                .collect::<Vec<_>>(),
             vec![
-                ("key1", &mut AttributeValue::from("val1")),
-                ("key2", &mut AttributeValue::from("val2")),
+                (Pair { key: "key1" }, &mut AttributeValue::from("val1")),
+                (Pair { key: "key2" }, &mut AttributeValue::from("val2")),
             ]
         );
     }
 
     #[test]
     fn iter_after_iter_mut() {
-        let mut attrs: Attributes = make_attrs(vec![("key1", "val1"), ("key2", "val2")]);
+        let mut attrs = Attributes::try_from("{key1=val1 key2=val2}").unwrap();
 
         for (attr, value) in &mut attrs {
-            if attr == "key2" {
+            if attr.key() == "key2" {
                 *value = "new_val".into();
             }
         }
@@ -793,8 +1004,8 @@ mod test {
         assert_eq!(
             attrs.iter().collect::<Vec<_>>(),
             vec![
-                ("key1", &AttributeValue::from("val1")),
-                ("key2", &AttributeValue::from("new_val")),
+                (Pair { key: "key1" }, &AttributeValue::from("val1")),
+                (Pair { key: "key2" }, &AttributeValue::from("new_val")),
             ]
         );
     }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -422,6 +422,26 @@ impl<'s> FromIterator<(AttributeKind<'s>, &'s str)> for Attributes<'s> {
     }
 }
 
+impl<'s> FromIterator<AttributeElem<'s>> for Attributes<'s> {
+    /// Create `Attributes` from an iterator of elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let e0 = (AttributeKind::Class, AttributeValue::from("a"));
+    /// let e1 = (AttributeKind::Id, AttributeValue::from("b"));
+    /// let a: Attributes = [e0.clone(), e1.clone()].into_iter().collect();
+    /// assert_eq!(format!("{:?}", a), "{.a #b}");
+    /// let mut elems = a.into_iter();
+    /// assert_eq!(elems.next(), Some(e0));
+    /// assert_eq!(elems.next(), Some(e1));
+    /// ```
+    fn from_iter<I: IntoIterator<Item = AttributeElem<'s>>>(iter: I) -> Self {
+        Attributes(iter.into_iter().collect())
+    }
+}
+
 impl<'s> std::fmt::Debug for Attributes<'s> {
     /// Formats the attributes using the given formatter.
     ///

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -38,6 +38,9 @@ impl<'s> AttributeValue<'s> {
 
     // lifetime is 's to avoid allocation if empty value is concatenated with single value
     fn extend(&mut self, s: &'s str) {
+        if s.is_empty() {
+            return;
+        }
         match &mut self.raw {
             CowStr::Borrowed(prev) => {
                 if prev.is_empty() {
@@ -47,8 +50,12 @@ impl<'s> AttributeValue<'s> {
                 }
             }
             CowStr::Owned(ref mut prev) => {
-                prev.push(' ');
-                prev.push_str(s);
+                if prev.is_empty() {
+                    self.raw = s.into();
+                } else {
+                    prev.push(' ');
+                    prev.push_str(s);
+                }
             }
         }
     }
@@ -743,7 +750,7 @@ mod test {
             Attributes::try_from("{.a #a class=b #b .c}")
                 .unwrap()
                 .get("class"),
-            Some(&"a  b c".into()), // bug: extra space?
+            Some(&"a b c".into()),
         );
     }
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -24,12 +24,18 @@ pub(crate) fn valid(src: &str) -> usize {
 
 /// Stores an attribute value that supports backslash escapes of ASCII punctuation upon displaying,
 /// without allocating.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub struct AttributeValue<'s> {
     raw: CowStr<'s>,
 }
 
 impl<'s> AttributeValue<'s> {
+    /// Create an empty attribute value.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Processes the attribute value escapes and returns an iterator of the parts of the value
     /// that should be displayed.
     pub fn parts(&'s self) -> AttributeValueParts<'s> {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1,7 +1,7 @@
 use crate::CowStr;
 use std::fmt;
 
-pub fn valid(src: &str) -> usize {
+pub(crate) fn valid(src: &str) -> usize {
     use State::*;
 
     let mut n = 0;

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -363,6 +363,18 @@ impl<'s> TryFrom<&'s str> for Attributes<'s> {
     }
 }
 
+impl<'s> From<Vec<AttributeElem<'s>>> for Attributes<'s> {
+    fn from(v: Vec<AttributeElem<'s>>) -> Self {
+        Self(v)
+    }
+}
+
+impl<'s> From<Attributes<'s>> for Vec<AttributeElem<'s>> {
+    fn from(a: Attributes<'s>) -> Self {
+        a.0
+    }
+}
+
 impl<'s> std::ops::Deref for Attributes<'s> {
     type Target = Vec<AttributeElem<'s>>;
 
@@ -970,6 +982,15 @@ mod test {
                 .get_value("class"),
             Some("a b c".into()),
         );
+    }
+
+    #[test]
+    fn from_to_vec() {
+        let v0: Vec<(AttributeKind, AttributeValue)> = vec![(Class, "a".into()), (Id, "b".into())];
+        let a: Attributes = v0.clone().into();
+        assert_eq!(format!("{:?}", a), "{.a #b}");
+        let v1: Vec<(AttributeKind, AttributeValue)> = a.into();
+        assert_eq!(v0, v1);
     }
 
     #[test]

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -288,6 +288,16 @@ impl<'s> FromIterator<(&'s str, &'s str)> for Attributes<'s> {
 }
 
 impl<'s> std::fmt::Debug for Attributes<'s> {
+    /// Formats the attributes using the given formatter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use jotdown::*;
+    /// let a = r#"{#a .b id=c class=d key="val" %comment%}"#;
+    /// let b = r#"{id="c", class="b d", key="val"}"#;
+    /// assert_eq!(format!("{:?}", Attributes::try_from(a).unwrap()), b);
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;
         let mut first = true;

--- a/src/html.rs
+++ b/src/html.rs
@@ -409,7 +409,7 @@ impl<'s> Writer<'s> {
             Event::NonBreakingSpace => out.write_str("&nbsp;")?,
             Event::Hardbreak => out.write_str("<br>\n")?,
             Event::Softbreak => out.write_char('\n')?,
-            Event::Escape | Event::Blankline => {}
+            Event::Escape | Event::Blankline | Event::Attributes(..) => {}
             Event::ThematicBreak(attrs) => {
                 if self.not_first_line {
                     out.write_char('\n')?;

--- a/src/html.rs
+++ b/src/html.rs
@@ -208,7 +208,7 @@ impl<'s> Writer<'s> {
                     Container::LinkDefinition { .. } => return Ok(()),
                 }
 
-                for (a, v) in attrs.into_iter().filter(|(a, _)| *a != "class") {
+                for (a, v) in attrs.unique_pairs().filter(|(a, _)| *a != "class") {
                     write!(out, r#" {}=""#, a)?;
                     v.parts().try_for_each(|part| write_attr(part, &mut out))?;
                     out.write_char('"')?;
@@ -221,14 +221,14 @@ impl<'s> Writer<'s> {
                 }
                 | Container::Section { id } = &c
                 {
-                    if !attrs.into_iter().any(|(a, _)| a == "id") {
+                    if !attrs.unique_pairs().any(|(a, _)| a == "id") {
                         out.write_str(r#" id=""#)?;
                         write_attr(id, &mut out)?;
                         out.write_char('"')?;
                     }
                 }
 
-                if attrs.into_iter().any(|(a, _)| a == "class")
+                if attrs.unique_pairs().any(|(a, _)| a == "class")
                     || matches!(
                         c,
                         Container::Div { class } if !class.is_empty())
@@ -254,7 +254,7 @@ impl<'s> Writer<'s> {
                         out.write_str(cls)?;
                     }
                     for cls in attrs
-                        .into_iter()
+                        .unique_pairs()
                         .filter(|(a, _)| a == &"class")
                         .map(|(_, cls)| cls)
                     {
@@ -415,7 +415,7 @@ impl<'s> Writer<'s> {
                     out.write_char('\n')?;
                 }
                 out.write_str("<hr")?;
-                for (a, v) in attrs {
+                for (a, v) in attrs.unique_pairs() {
                     write!(out, r#" {}=""#, a)?;
                     v.parts().try_for_each(|part| write_attr(part, &mut out))?;
                     out.write_char('"')?;

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -516,7 +516,9 @@ impl<'s> Parser<'s> {
                 .chain(self.input.ahead.iter().take(state.valid_lines).cloned())
             {
                 let line = line.start..usize::min(state.end_attr, line.end);
-                parser.parse(&self.input.src[line]);
+                parser
+                    .parse(&self.input.src[line])
+                    .expect("should be valid");
             }
             parser.finish()
         };

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -1736,6 +1736,13 @@ mod test {
         );
         test_parse!(
             "_abc def_{ % comment % } ghi",
+            (
+                Attributes {
+                    container: true,
+                    attrs: 0
+                },
+                "{ % comment % }"
+            ),
             (Enter(Emphasis), "_"),
             (Str, "abc def"),
             (Exit(Emphasis), "_{ % comment % }"),
@@ -1821,7 +1828,20 @@ mod test {
     #[test]
     fn attr_empty() {
         test_parse!("word{}", (Str, "word"));
-        test_parse!("word{ % comment % } trail", (Str, "word"), (Str, " trail"));
+        test_parse!(
+            "word{ % comment % } trail",
+            (
+                Attributes {
+                    container: false,
+                    attrs: 0
+                },
+                "{ % comment % }"
+            ),
+            (Enter(Span), ""),
+            (Str, "word"),
+            (Exit(Span), "{ % comment % }"),
+            (Str, " trail")
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1220,12 +1220,17 @@ mod test {
                 concat!(
                     "\n",
                     "\x1b[0;1m====================== INPUT =========================\x1b[0m\n",
-                    "\x1b[2m{}",
+                    "\x1b[2m{}{}",
                     "\x1b[0;1m================ ACTUAL vs EXPECTED ==================\x1b[0m\n",
                     "{}",
                     "\x1b[0;1m======================================================\x1b[0m\n",
                 ),
                 $src,
+                if $src.ends_with('\n') {
+                    ""
+                } else {
+                    "\n"
+                },
                 {
                     let a = actual.iter().map(|n| format!("{:?}", n)).collect::<Vec<_>>();
                     let b = expected.iter().map(|n| format!("{:?}", n)).collect::<Vec<_>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,7 @@ mod inline;
 mod lex;
 
 pub use attr::{
-    AttributeKind, AttributeValue, AttributeValueParts, Attributes, AttributesIntoIter,
-    AttributesIter, AttributesIterMut, ParseAttributesError,
+    AttributeKind, AttributeValue, AttributeValueParts, Attributes, ParseAttributesError,
 };
 
 type CowStr<'s> = std::borrow::Cow<'s, str>;
@@ -967,9 +966,10 @@ impl<'s> Parser<'s> {
                                 .get::<str>(tag.as_ref())
                                 .cloned();
 
-                            let (url_or_tag, ty) = if let Some((url, attrs_def)) = link_def {
+                            let (url_or_tag, ty) = if let Some((url, mut attrs_def)) = link_def {
                                 if enter {
-                                    attributes.concat(attrs_def);
+                                    attrs_def.append(&mut attributes);
+                                    attributes = attrs_def;
                                 }
                                 (url, SpanLinkType::Reference)
                             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2224,6 +2224,22 @@ mod test {
             (Str("para".into()), "para"),
             (End(Paragraph), ""),
         );
+        test_parse!(
+            concat!(
+                "{.a}\n",
+                "{#b}\n",
+                "para\n", //
+            ),
+            (
+                Start(
+                    Paragraph,
+                    [("class", "a"), ("id", "b")].into_iter().collect(),
+                ),
+                "{.a}\n{#b}\n",
+            ),
+            (Str("para".into()), "para"),
+            (End(Paragraph), ""),
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2330,6 +2330,7 @@ mod test {
                     Emphasis,
                     [
                         (AttributeKind::Class, "a"),
+                        (AttributeKind::Comment, ""),
                         (AttributeKind::Class, "b"),
                         (AttributeKind::Id, "i"),
                     ]
@@ -2377,6 +2378,7 @@ mod test {
                         (AttributeKind::Class, "a"),
                         (AttributeKind::Class, "b"),
                         (AttributeKind::Id, "i"),
+                        (AttributeKind::Comment, ""),
                     ]
                     .into_iter()
                     .collect(),
@@ -2398,6 +2400,7 @@ mod test {
                         (AttributeKind::Class, "a"),
                         (AttributeKind::Class, "b"),
                         (AttributeKind::Id, "i"),
+                        (AttributeKind::Comment, ""),
                     ]
                     .into_iter()
                     .collect(),
@@ -2450,9 +2453,12 @@ mod test {
             (
                 Start(
                     Span,
-                    [(AttributeKind::Pair { key: "a" }, "a")]
-                        .into_iter()
-                        .collect(),
+                    [
+                        (AttributeKind::Comment, ""),
+                        (AttributeKind::Pair { key: "a" }, "a"),
+                    ]
+                    .into_iter()
+                    .collect(),
                 ),
                 "",
             ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2416,6 +2416,11 @@ impl<'s> Parser<'s> {
                     inline::Atom::Hardbreak => Event::Hardbreak,
                     inline::Atom::Escape => Event::Escape,
                 },
+                inline::EventKind::Empty => {
+                    debug_assert!(!attributes.is_empty());
+                    attributes.clear();
+                    Event::Escape // TODO replace dummy
+                }
                 inline::EventKind::Str => Event::Str(self.src[inline.span.clone()].into()),
                 inline::EventKind::Attributes { .. } | inline::EventKind::Placeholder => {
                     panic!("{:?}", inline)

--- a/tests/afl/src/lib.rs
+++ b/tests/afl/src/lib.rs
@@ -15,17 +15,6 @@ pub fn parse(data: &[u8]) {
             // no overlap, out of order
             assert!(
                 last.1.end <= range.start
-                // block attributes may overlap with start event
-                || (
-                    matches!(last.0, jotdown::Event::Blankline)
-                    && (
-                        matches!(
-                            event,
-                            jotdown::Event::Start(ref cont, ..) if cont.is_block()
-                        )
-                        || matches!(event, jotdown::Event::ThematicBreak(..))
-                    )
-                )
                 // caption event is before table rows but src is after
                 || (
                     matches!(

--- a/tests/html-ut/skip
+++ b/tests/html-ut/skip
@@ -1,6 +1,5 @@
 38d85f9:multi-line block attributes
 6c14561:multi-line block attributes
-f4f22fc:attribute key class order
 ae6fc15:bugged left/right quote
 168469a:bugged left/right quote
 2fa94d1:bugged left/right quote

--- a/tests/html-ut/ut/attributes.test
+++ b/tests/html-ut/ut/attributes.test
@@ -3,5 +3,16 @@ Classes should be concatenated
 ```
 word{.a #a class=b #b .c}
 .
-<p><span id="b" class="a b c">word</span></p>
+<p><span class="a b c" id="b">word</span></p>
+```
+
+Automatic and explicit classes should be merged correctly
+
+```
+{.a}
+::: b
+:::
+.
+<div class="a b">
+</div>
 ```

--- a/tests/html-ut/ut/attributes.test
+++ b/tests/html-ut/ut/attributes.test
@@ -3,5 +3,5 @@ Classes should be concatenated
 ```
 word{.a #a class=b #b .c}
 .
-<p><span id="b" class="a  b c">word</span></p>
+<p><span id="b" class="a b c">word</span></p>
 ```

--- a/tests/html-ut/ut/attributes.test
+++ b/tests/html-ut/ut/attributes.test
@@ -1,0 +1,7 @@
+Classes should be concatenated
+
+```
+word{.a #a class=b #b .c}
+.
+<p><span id="b" class="a  b c">word</span></p>
+```


### PR DESCRIPTION
- simplify attributes by just making it a vec of the attribute key-value pairs in the order that they appear, instead of emulating a map without duplicates. this makes attributes more flexible and easier to manipulate (can use all of vec functions), while avoiding losing information about the input,
- add unique_pairs helper function for when a map-like set is needed (e.g. for rendering)
- include comments in attributes,
- emit events for attributes that are not attached to anything

having events better match the source code can be useful for applications such as linters and formatters.

should resolve #55