### PR TITLE
Make html formatting configurable

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -300,6 +300,12 @@ impl<'s> TreeParser<'s> {
 
             // skip outer block part for inner content
             lines[0].start += outer_len;
+            if matches!(kind, Kind::Blockquote)
+                && lines[0].start < lines[0].end
+                && matches!(self.src.as_bytes()[lines[0].start], b'\t' | b' ')
+            {
+                lines[0].start += 1;
+            }
 
             // skip opening and closing fence of code block / div
             let lines = if let Kind::Fenced {

--- a/src/help.txt
+++ b/src/help.txt
@@ -8,3 +8,8 @@ options:
     -h --help       show this text
     -v --version    show the version number
     -o --output     a file to write the output to. stdout if omitted
+
+formatting options:
+    --minified           emit no whitespace between elements in output
+    --indent-string      string to use as indentation in output, empty by default
+    --start-indent       initial indentation level of output, 0 by default

--- a/src/html.rs
+++ b/src/html.rs
@@ -313,7 +313,7 @@ struct Writer<'s, 'f> {
     raw: Raw,
     img_alt_text: usize,
     list_tightness: Vec<bool>,
-    not_first_line: bool,
+    first_line: bool,
     ignore: bool,
     footnotes: Footnotes<'s>,
 }
@@ -331,7 +331,7 @@ impl<'s, 'f> Writer<'s, 'f> {
             raw: Raw::default(),
             img_alt_text: 0,
             list_tightness: Vec::new(),
-            not_first_line: false,
+            first_line: true,
             ignore: false,
             footnotes: Footnotes::default(),
         }
@@ -345,7 +345,7 @@ impl<'s, 'f> Writer<'s, 'f> {
             return Ok(());
         }
 
-        if self.not_first_line {
+        if !self.first_line {
             out.write_char('\n')?;
         }
 
@@ -697,7 +697,7 @@ impl<'s, 'f> Writer<'s, 'f> {
                 out.write_str(">")?;
             }
         }
-        self.not_first_line = true;
+        self.first_line = false;
 
         Ok(())
     }

--- a/tests/html-ut/ut/block_quotes.test
+++ b/tests/html-ut/ut/block_quotes.test
@@ -1,0 +1,63 @@
+```
+> ```
+>
+> 123
+>    456
+> ```
+.
+<blockquote>
+<pre><code>
+123
+   456
+</code></pre>
+</blockquote>
+```
+
+```
+>  ```
+>
+> 123
+>    456
+> ```
+.
+<blockquote>
+<pre><code>
+123
+  456
+</code></pre>
+</blockquote>
+```
+
+```
+>  ```
+>
+>  123
+>     456
+>  ```
+.
+<blockquote>
+<pre><code>
+123
+   456
+</code></pre>
+</blockquote>
+```
+
+```
+> - a
+>
+>  - b
+.
+<blockquote>
+<ul>
+<li>
+a
+<ul>
+<li>
+b
+</li>
+</ul>
+</li>
+</ul>
+</blockquote>
+```


### PR DESCRIPTION
possibly a slight performance hit on renderer but overall it is mostly unaffected

```
model name	: AMD Ryzen 9 5950X 16-Core Processor
commit                                                   criterion:full/readme [MB/s]  criterion:html/readme [MB/s]
8ebed5be6 lib: include type of char used for list items  109.41                        40.392
b42d68976 block: fix blockquote code block indent        107.07                        40.460
a41fa2996 html: add optional minified formatting         104.90                        36.755
0ed21b590 html: add optional indented formatting         112.60                        39.880
d260fb2c1 html: make initial indent level configurable   107.28                        38.868
```