### PR TITLE
Fix link definition parsing being too greedy

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -980,18 +980,22 @@ impl<'s> IdentifiedBlock<'s> {
                     None
                 }
             }
-            '[' => chars.as_str().find("]:").map(|l| {
-                let label = &chars.as_str()[0..l];
-                let footnote = label.starts_with('^');
-                (
-                    Kind::Definition {
-                        indent,
-                        footnote,
-                        label: &label[usize::from(footnote)..],
-                        last_blankline: false,
-                    },
-                    0..(indent + 3 + l),
-                )
+            '[' => chars.as_str().find("]").and_then(|l| {
+                if chars.clone().nth(l + 1) == Some(':') {
+                    let label = &chars.as_str()[0..l];
+                    let footnote = label.starts_with('^');
+                    Some((
+                        Kind::Definition {
+                            indent,
+                            footnote,
+                            label: &label[usize::from(footnote)..],
+                            last_blankline: false,
+                        },
+                        0..(indent + 3 + l),
+                    ))
+                } else {
+                    None
+                }
             }),
             '-' | '*' if Self::is_thematic_break(chars.clone()) => {
                 Some((Kind::Atom(ThematicBreak), indent..(indent + lt)))

--- a/tests/html-ut/ut/link_definitions.test
+++ b/tests/html-ut/ut/link_definitions.test
@@ -1,0 +1,7 @@
+```
+[foo][bar]: click me
+
+[bar]: https://example.com
+.
+<p><a href="https://example.com">foo</a>: click me</p>
+```


### PR DESCRIPTION
Currently, the following snippet:

```
[foo][bar]: click me

[bar]: https://example.com
```

will be parsed as

```
Start(LinkDefinition { label: "foo][bar" }, {})
Str("click me")
End(LinkDefinition { label: "foo][bar" })
```

leading to somewhat surprising results. This happens not only when that construct is the start of a paragraph, but also when it is the start of a list item:

```
* [foo][bar]: click me
* [foo][bar] - click me, too

[bar]: https://example.com
```

First link does not render, the second one will. This behavior is rooted in an somewhat too greedy approach to identifying the closing `]:` when a link definition is possible.

This commit fixes that by asserting that `]:` is found at the _first_ occurance of `]` when looking for a LinkDefinition.