### PR TITLE
Handle repeated attribute specifiers in pre-pass

### DIFF
--- a/tests/html-ut/ut/link_definitions.test
+++ b/tests/html-ut/ut/link_definitions.test
@@ -1,7 +1,21 @@
+Link definitions must not be parsed to greedily
+
 ```
 [foo][bar]: click me
 
 [bar]: https://example.com
 .
 <p><a href="https://example.com">foo</a>: click me</p>
+```
+
+Link definitions (i.e. pre-pass) supports repeated attribute specifiers
+
+```
+[foo][bar]: click me
+
+{title="Example link"}
+{rel="external"}
+[bar]: https://example.com
+.
+<p><a href="https://example.com" title="Example link" rel="external">foo</a>: click me</p>
 ```


### PR DESCRIPTION
While the regular parser handles repeated attribute specifiers just fine, pre-pass does not - it only keeps track of the last attribute specifier it encountered, leading to for example this snippet:

```
[foo][bar]: click me

{title="Example link"}
{rel="external"}
[bar]: https://example.com
```

being rendered as

```
<p><a href="https://example.com" rel="external">foo</a>: click me</p>
```

 (note the missing title).

This commit fixes that by having the pre-pass keep track of a list of attribute specifiers instead of just a single one.