### PR TITLE
Close code block with fence longer than opening

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1244,9 +1244,7 @@ impl<'s> Kind<'s> {
                 } = IdentifiedBlock::new(line).kind
                 {
                     if spec.is_empty() {
-                        *has_closing_fence = k == *kind
-                            && (l == *fence_length
-                                || (matches!(k, FenceKind::Div) && l > *fence_length));
+                        *has_closing_fence = k == *kind && l >= *fence_length;
                     }
                 }
                 true

--- a/tests/html-ut/ut/raw_blocks.test
+++ b/tests/html-ut/ut/raw_blocks.test
@@ -17,3 +17,14 @@ paragraph
 </tag2>
 </tag1>
 ````
+
+A code block "ends with a line of backticks equal or greater in length to the opening backtick fence"
+
+`````
+```
+foo
+````
+.
+<pre><code>foo
+</code></pre>
+`````


### PR DESCRIPTION
As described in the [djot spec][1]. Currently, for code blocks, only a fence of equal length is accepted.

[1]: https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html#code-block