### PR TITLE
Fix lexer eating ! before plain span

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -42,7 +42,7 @@ pub enum Delimiter {
 pub enum Symbol {
     Asterisk,
     Caret,
-    ExclaimBracket,
+    Exclaim,
     Lt,
     Pipe,
     Quote1,
@@ -238,14 +238,7 @@ impl<'s> Lexer<'s> {
                         }
                     }
 
-                    b'!' => {
-                        if self.peek_byte() == Some(b'[') {
-                            self.eat_byte();
-                            Sym(ExclaimBracket)
-                        } else {
-                            Text
-                        }
-                    }
+                    b'!' => Sym(Exclaim),
                     b'<' => Sym(Lt),
                     b'|' => Sym(Pipe),
                     b':' => Sym(Colon),
@@ -386,11 +379,11 @@ mod test {
     #[test]
     fn sym() {
         test_lex!(
-            r#"'*^![<|"~_"#,
+            r#"'*^!<|"~_"#,
             Sym(Quote1).l(1),
             Sym(Asterisk).l(1),
             Sym(Caret).l(1),
-            Sym(ExclaimBracket).l(2),
+            Sym(Exclaim).l(1),
             Sym(Lt).l(1),
             Sym(Pipe).l(1),
             Sym(Quote2).l(1),


### PR DESCRIPTION
Currently, `foo![bar]{.cls}` will swallow the exclamation mark, because it is first lexed as opener of an image link, then later the converted to a plain span because it has attributes but no URL.

The reference implementation handles this correctly [1].

To mitigate, do not lex `![` as special symbol. Instead, check during span-to-link conversion if the opener was preceeded by a `!` and modify events accordingly if so.

[1] https://djot.net/playground/?text=%21%5Bspan%5D%7B.bar%7D&mode=html&sourcepos=false