### PR TITLE
readme: Fix name of Rust binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ this repository and run locally with cargo:
 
 ```
 $ cargo build --release
-$ echo "hello world" | ./target/release/djot
+$ echo "hello world" | ./target/release/jotdown
 <p>hello world</p>
 ```
 


### PR DESCRIPTION
If you build this project from source, the binary is called "jotdown". This patch fixes the name of the binary.