### PR TITLE
refactor: simplify Event::End 

### DIFF
--- a/bench/criterion/main.rs
+++ b/bench/criterion/main.rs
@@ -1,5 +1,6 @@
 use criterion::criterion_group;
 use criterion::criterion_main;
+use jotdown::RenderExt;
 
 fn gen_block(c: &mut criterion::Criterion) {
     let mut group = c.benchmark_group("block");
@@ -47,7 +48,7 @@ fn gen_html(c: &mut criterion::Criterion) {
             |b, &input| {
                 b.iter_batched(
                     || jotdown::Parser::new(input).collect::<Vec<_>>(),
-                    |p| jotdown::html::render_to_string(p.into_iter()),
+                    |p| jotdown::html::Renderer::default().render_events(p.into_iter()),
                     criterion::BatchSize::SmallInput,
                 );
             },
@@ -68,7 +69,7 @@ fn gen_html_clone(c: &mut criterion::Criterion) {
             |b, &input| {
                 b.iter_batched(
                     || jotdown::Parser::new(input).collect::<Vec<_>>(),
-                    |p| jotdown::html::render_to_string(p.iter().cloned()),
+                    |p| jotdown::html::Renderer::default().render_events(p.into_iter()),
                     criterion::BatchSize::SmallInput,
                 );
             },
@@ -85,9 +86,7 @@ fn gen_full(c: &mut criterion::Criterion) {
             criterion::BenchmarkId::from_parameter(name),
             input,
             |b, &input| {
-                b.iter_with_large_drop(|| {
-                    jotdown::html::render_to_string(jotdown::Parser::new(input))
-                });
+                b.iter_with_large_drop(|| jotdown::html::render_to_string(input));
             },
         );
     }

--- a/examples/jotdown_wasm/src/lib.rs
+++ b/examples/jotdown_wasm/src/lib.rs
@@ -11,7 +11,7 @@ pub fn jotdown_version() -> String {
 #[must_use]
 #[wasm_bindgen]
 pub fn jotdown_render(djot: &str) -> String {
-    jotdown::html::render_to_string(jotdown::Parser::new(djot))
+    jotdown::html::render_to_string(djot)
 }
 
 #[must_use]

--- a/examples/jotdown_wasm/src/lib.rs
+++ b/examples/jotdown_wasm/src/lib.rs
@@ -34,7 +34,7 @@ pub fn jotdown_parse_indent(djot: &str) -> String {
     let mut level = 0;
     let mut out = String::new();
     for e in jotdown::Parser::new(djot) {
-        if !matches!(e, jotdown::Event::End(..)) {
+        if !matches!(e, jotdown::Event::End) {
             // use non-breaking space for indent because normal spaces gets squeezed by browser
             let nbsp = '\u{00a0}';
             (0..4 * level).for_each(|_| out.push(nbsp));
@@ -58,7 +58,7 @@ pub fn jotdown_parse_indent(djot: &str) -> String {
                 }
                 out.push('\n');
             }
-            jotdown::Event::End(..) => {
+            jotdown::Event::End => {
                 level -= 1;
             }
             e => {

--- a/src/html.rs
+++ b/src/html.rs
@@ -13,22 +13,20 @@ use crate::SpanLinkType;
 
 /// Render events into a string.
 ///
-/// This is a convenience function for using [`Renderer::push`] with fewer imports and without an
-/// intermediate variable.
+/// This is a convenience function for rendering documents whole without any customizations.
 ///
 /// # Examples
 ///
 /// ```
-/// let events = jotdown::Parser::new("hello");
-/// assert_eq!(jotdown::html::render_to_string(events), "<p>hello</p>\n");
+/// assert_eq!(jotdown::html::render_to_string("hello"), "<p>hello</p>\n");
 /// ```
-pub fn render_to_string<'s, I>(events: I) -> String
-where
-    I: Iterator<Item = Event<'s>>,
-{
-    let mut s = String::new();
-    Renderer::default().push(events, &mut s).unwrap();
-    s
+pub fn render_to_string(doc: &str) -> String {
+    use crate::RenderExt;
+    let mut r = Renderer::default();
+
+    r.render_document(doc).unwrap();
+
+    r.into_inner()
 }
 
 #[derive(Clone)]
@@ -46,11 +44,9 @@ pub struct Indentation {
     /// # use jotdown::*;
     /// # use jotdown::html::*;
     /// let src = "> a\n";
-    /// let events = Parser::new(src);
     ///
-    /// let mut html = String::new();
     /// let renderer = Renderer::indented(Indentation::default());
-    /// renderer.push(events.clone(), &mut html).unwrap();
+    /// let html = renderer.render_to_string(src);
     /// assert_eq!(
     ///     html,
     ///     concat!(
@@ -66,14 +62,12 @@ pub struct Indentation {
     /// ```
     /// # use jotdown::*;
     /// # use jotdown::html::*;
-    /// # let src = "> a\n";
-    /// # let events = Parser::new(src);
-    /// # let mut html = String::new();
+    /// let src = "> a\n";
     /// let renderer = Renderer::indented(Indentation {
     ///     string: "    ".to_string(),
     ///     ..Indentation::default()
     /// });
-    /// renderer.push(events.clone(), &mut html).unwrap();
+    /// let html = renderer.render_to_string(src);
     /// assert_eq!(
     ///     html,
     ///     concat!(
@@ -94,11 +88,9 @@ pub struct Indentation {
     /// # use jotdown::*;
     /// # use jotdown::html::*;
     /// let src = "> a\n";
-    /// let events = Parser::new(src);
     ///
-    /// let mut html = String::new();
     /// let renderer = Renderer::indented(Indentation::default());
-    /// renderer.push(events.clone(), &mut html).unwrap();
+    /// let html = renderer.render_to_string(src);
     /// assert_eq!(
     ///     html,
     ///     concat!(
@@ -114,14 +106,12 @@ pub struct Indentation {
     /// ```
     /// # use jotdown::*;
     /// # use jotdown::html::*;
-    /// # let src = "> a\n";
-    /// # let events = Parser::new(src);
-    /// # let mut html = String::new();
+    /// let src = "> a\n";
     /// let renderer = Renderer::indented(Indentation {
     ///     initial_level: 2,
     ///     ..Indentation::default()
     /// });
-    /// renderer.push(events.clone(), &mut html).unwrap();
+    /// let html = renderer.render_to_string(src);
     /// assert_eq!(
     ///     html,
     ///     concat!(
@@ -147,12 +137,21 @@ impl Default for Indentation {
 ///
 /// By default, block elements are placed on separate lines. To configure the formatting of the
 /// output, see the [`Renderer::minified`] and [`Renderer::indented`] constructors.
-#[derive(Clone)]
-pub struct Renderer {
+pub struct Renderer<'s, W> {
     indent: Option<Indentation>,
+    writer: Writer<'s>,
+    output: W,
 }
 
-impl Renderer {
+impl<'s> Renderer<'s, String> {
+    fn new(indent: Option<Indentation>) -> Self {
+        Self {
+            writer: Writer::new(&indent),
+            indent,
+            output: String::new(),
+        }
+    }
+
     /// Create a renderer that emits no whitespace between elements.
     ///
     /// # Examples
@@ -167,16 +166,15 @@ impl Renderer {
     ///     "\n",
     ///     "  - c\n",
     /// );
-    /// let mut actual = String::new();
     /// let renderer = Renderer::minified();
-    /// renderer.push(Parser::new(src), &mut actual).unwrap();
+    /// let actual = renderer.render_to_string(src);
     /// let expected =
     ///     "<ul><li>a<ul><li><p>b</p></li><li><p>c</p></li></ul></li></ul>";
     /// assert_eq!(actual, expected);
     /// ```
     #[must_use]
     pub fn minified() -> Self {
-        Self { indent: None }
+        Self::new(None)
     }
 
     /// Create a renderer that indents lines based on their block element depth.
@@ -195,9 +193,8 @@ impl Renderer {
     ///     "\n",
     ///     "  - c\n",
     /// );
-    /// let mut actual = String::new();
     /// let renderer = Renderer::indented(Indentation::default());
-    /// renderer.push(Parser::new(src), &mut actual).unwrap();
+    /// let actual = renderer.render_to_string(src);
     /// let expected = concat!(
     ///     "<ul>\n",
     ///     "\t<li>\n",
@@ -217,13 +214,30 @@ impl Renderer {
     /// ```
     #[must_use]
     pub fn indented(indent: Indentation) -> Self {
-        Self {
-            indent: Some(indent),
-        }
+        Self::new(Some(indent))
+    }
+
+    pub fn render_to_string(self, input: &str) -> String {
+        use super::RenderExt;
+        let mut s = self.with_fmt_writer(String::new());
+        s.render_document(input).expect("Can't fail");
+
+        s.into_inner()
+    }
+
+    pub fn render_events_to_string<I>(self, events: I) -> String
+    where
+        I: Iterator<Item = Event<'s>>,
+    {
+        use super::RenderExt;
+        let mut s = self.with_fmt_writer(String::new());
+        s.render_events(events).expect("Can't fail");
+
+        s.into_inner()
     }
 }
 
-impl Default for Renderer {
+impl<'s> Default for Renderer<'s, String> {
     /// Place block elements on separate lines.
     ///
     /// This is the default behavior and matches the reference implementation.
@@ -240,9 +254,8 @@ impl Default for Renderer {
     ///     "\n",
     ///     "  - c\n",
     /// );
-    /// let mut actual = String::new();
     /// let renderer = Renderer::default();
-    /// renderer.push(Parser::new(src), &mut actual).unwrap();
+    /// let actual = renderer.render_to_string(src);
     /// let expected = concat!(
     ///     "<ul>\n",
     ///     "<li>\n",
@@ -261,24 +274,129 @@ impl Default for Renderer {
     /// assert_eq!(actual, expected);
     /// ```
     fn default() -> Self {
+        Renderer::new(Some(Indentation {
+            string: String::new(),
+            initial_level: 0,
+        }))
+    }
+}
+
+impl<'s, W> Renderer<'s, W> {
+    pub fn into_inner(self) -> W {
+        self.output
+    }
+}
+
+pub struct WriteAdapter<T: std::io::Write>(T);
+
+struct WriteAdapterInner<T: std::io::Write> {
+    inner: T,
+    error: std::io::Result<()>,
+}
+
+impl<T: std::io::Write> WriteAdapterInner<T> {
+    fn new(output: T) -> Self {
         Self {
-            indent: Some(Indentation {
-                string: String::new(),
-                initial_level: 0,
-            }),
+            inner: output,
+            error: Ok(()),
+        }
+    }
+}
+impl<T: std::io::Write> std::fmt::Write for WriteAdapterInner<T> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.inner.write_all(s.as_bytes()).map_err(|e| {
+            self.error = Err(e);
+            std::fmt::Error
+        })
+    }
+}
+
+impl<'s, W> Renderer<'s, W> {
+    pub fn with_io_writer<NewWriter>(
+        self,
+        output: NewWriter,
+    ) -> Renderer<'s, WriteAdapter<NewWriter>>
+    where
+        NewWriter: std::io::Write,
+    {
+        let Renderer {
+            indent,
+            writer,
+            output: _,
+        } = self;
+
+        let output = WriteAdapter(output);
+        Renderer {
+            indent,
+            writer,
+            output,
+        }
+    }
+
+    pub fn with_fmt_writer<NewWriter>(self, output: NewWriter) -> Renderer<'s, NewWriter>
+    where
+        NewWriter: std::fmt::Write,
+    {
+        let Renderer {
+            indent,
+            writer,
+            output: _,
+        } = self;
+
+        Renderer {
+            indent,
+            writer,
+            output,
         }
     }
 }
 
-impl Render for Renderer {
-    fn push<'s, I, W>(&self, mut events: I, mut out: W) -> std::fmt::Result
-    where
-        I: Iterator<Item = Event<'s>>,
-        W: std::fmt::Write,
-    {
-        let mut w = Writer::new(&self.indent);
-        events.try_for_each(|e| w.render_event(e, &mut out))?;
-        w.render_epilogue(&mut out)
+impl<'s, W> Render<'s> for Renderer<'s, W>
+where
+    W: std::fmt::Write,
+{
+    type Error = std::fmt::Error;
+
+    fn begin(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Called iteratively with every single event emitted by parsing djot document
+    fn emit(&mut self, event: Event<'s>) -> Result<(), Self::Error> {
+        self.writer
+            .render_event(event, &mut self.output, &self.indent)
+    }
+
+    /// Called at the end of rendering a djot document
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        self.writer.render_epilogue(&mut self.output, &self.indent)
+    }
+}
+
+impl<'s, W> Render<'s> for Renderer<'s, WriteAdapter<W>>
+where
+    W: std::io::Write,
+{
+    type Error = std::io::Error;
+
+    fn begin(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Called iteratively with every single event emitted by parsing djot document
+    fn emit(&mut self, event: Event<'s>) -> Result<(), Self::Error> {
+        let mut adapter = WriteAdapterInner::new(&mut self.output.0);
+        self.writer
+            .render_event(event, &mut adapter, &self.indent)
+            .map_err(|_| adapter.error.expect_err("Inner adapter always sets error"))
+    }
+
+    /// Called at the end of rendering a djot document
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        let mut adapter = WriteAdapterInner::new(&mut self.output.0);
+        self.writer
+            .render_epilogue(&mut adapter, &self.indent)
+            .map_err(|_| adapter.error.expect_err("Inner adapter always sets error"))
     }
 }
 
@@ -294,8 +412,7 @@ impl Default for Raw {
     }
 }
 
-struct Writer<'s, 'f> {
-    indent: &'f Option<Indentation>,
+struct Writer<'s> {
     depth: usize,
     raw: Raw,
     img_alt_text: usize,
@@ -305,15 +422,14 @@ struct Writer<'s, 'f> {
     footnotes: Footnotes<'s>,
 }
 
-impl<'s, 'f> Writer<'s, 'f> {
-    fn new(indent: &'f Option<Indentation>) -> Self {
+impl<'s> Writer<'s> {
+    fn new(indent: &Option<Indentation>) -> Self {
         let depth = if let Some(indent) = indent {
             indent.initial_level
         } else {
             0
         };
         Self {
-            indent,
             depth,
             raw: Raw::default(),
             img_alt_text: 0,
@@ -324,11 +440,16 @@ impl<'s, 'f> Writer<'s, 'f> {
         }
     }
 
-    fn block<W>(&mut self, mut out: W, depth_change: isize) -> std::fmt::Result
+    fn block<W>(
+        &mut self,
+        mut out: W,
+        indent: &Option<Indentation>,
+        depth_change: isize,
+    ) -> std::fmt::Result
     where
         W: std::fmt::Write,
     {
-        if self.indent.is_none() {
+        if indent.is_none() {
             return Ok(());
         }
 
@@ -340,7 +461,7 @@ impl<'s, 'f> Writer<'s, 'f> {
         if depth_change < 0 {
             self.depth = next_depth;
         }
-        self.indent(&mut out)?;
+        self.indent(&mut out, indent)?;
         if depth_change > 0 {
             self.depth = next_depth;
         }
@@ -348,11 +469,11 @@ impl<'s, 'f> Writer<'s, 'f> {
         Ok(())
     }
 
-    fn indent<W>(&self, mut out: W) -> std::fmt::Result
+    fn indent<W>(&self, mut out: W, indent: &Option<Indentation>) -> std::fmt::Result
     where
         W: std::fmt::Write,
     {
-        if let Some(indent) = self.indent {
+        if let Some(indent) = indent {
             if !indent.string.is_empty() {
                 for _ in 0..self.depth {
                     out.write_str(&indent.string)?;
@@ -362,7 +483,12 @@ impl<'s, 'f> Writer<'s, 'f> {
         Ok(())
     }
 
-    fn render_event<W>(&mut self, e: Event<'s>, mut out: W) -> std::fmt::Result
+    fn render_event<W>(
+        &mut self,
+        e: Event<'s>,
+        mut out: W,
+        indent: &Option<Indentation>,
+    ) -> std::fmt::Result
     where
         W: std::fmt::Write,
     {
@@ -395,7 +521,7 @@ impl<'s, 'f> Writer<'s, 'f> {
         match e {
             Event::Start(c, attrs) => {
                 if c.is_block() {
-                    self.block(&mut out, c.is_block_container().into())?;
+                    self.block(&mut out, indent, c.is_block_container().into())?;
                 }
                 if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
                     return Ok(());
@@ -562,7 +688,7 @@ impl<'s, 'f> Writer<'s, 'f> {
                     }
                     Container::TaskListItem { checked } => {
                         out.write_char('>')?;
-                        self.block(&mut out, 0)?;
+                        self.block(&mut out, indent, 0)?;
                         if checked {
                             out.write_str(r#"<input disabled="" type="checkbox" checked=""/>"#)?;
                         } else {
@@ -574,7 +700,7 @@ impl<'s, 'f> Writer<'s, 'f> {
             }
             Event::End(c) => {
                 if c.is_block_container() {
-                    self.block(&mut out, -1)?;
+                    self.block(&mut out, indent, -1)?;
                 }
                 if self.img_alt_text > 0 && !matches!(c, Container::Image(..)) {
                     return Ok(());
@@ -670,15 +796,15 @@ impl<'s, 'f> Writer<'s, 'f> {
             Event::NonBreakingSpace => out.write_str("&nbsp;")?,
             Event::Hardbreak => {
                 out.write_str("<br>")?;
-                self.block(out, 0)?;
+                self.block(out, indent, 0)?;
             }
             Event::Softbreak => {
                 out.write_char('\n')?;
-                self.indent(&mut out)?;
+                self.indent(&mut out, indent)?;
             }
             Event::Escape | Event::Blankline | Event::Attributes(..) => {}
             Event::ThematicBreak(attrs) => {
-                self.block(&mut out, 0)?;
+                self.block(&mut out, indent, 0)?;
                 out.write_str("<hr")?;
                 for (a, v) in attrs.unique_pairs() {
                     write!(out, r#" {}=""#, a)?;
@@ -693,20 +819,20 @@ impl<'s, 'f> Writer<'s, 'f> {
         Ok(())
     }
 
-    fn render_epilogue<W>(&mut self, mut out: W) -> std::fmt::Result
+    fn render_epilogue<W>(&mut self, mut out: W, indent: &Option<Indentation>) -> std::fmt::Result
     where
         W: std::fmt::Write,
     {
         if self.footnotes.reference_encountered() {
-            self.block(&mut out, 0)?;
+            self.block(&mut out, indent, 0)?;
             out.write_str("<section role=\"doc-endnotes\">")?;
-            self.block(&mut out, 0)?;
+            self.block(&mut out, indent, 0)?;
             out.write_str("<hr>")?;
-            self.block(&mut out, 0)?;
+            self.block(&mut out, indent, 0)?;
             out.write_str("<ol>")?;
 
             while let Some((number, events)) = self.footnotes.next() {
-                self.block(&mut out, 0)?;
+                self.block(&mut out, indent, 0)?;
                 write!(out, "<li id=\"fn{}\">", number)?;
 
                 let mut unclosed_para = false;
@@ -718,13 +844,13 @@ impl<'s, 'f> Writer<'s, 'f> {
                         // not a footnote, so no need to add href before para close
                         out.write_str("</p>")?;
                     }
-                    self.render_event(e.clone(), &mut out)?;
+                    self.render_event(e.clone(), &mut out, indent)?;
                     unclosed_para = matches!(e, Event::End(Container::Paragraph { .. }))
                         && !matches!(self.list_tightness.last(), Some(true));
                 }
                 if !unclosed_para {
                     // create a new paragraph
-                    self.block(&mut out, 0)?;
+                    self.block(&mut out, indent, 0)?;
                     out.write_str("<p>")?;
                 }
                 write!(
@@ -733,17 +859,17 @@ impl<'s, 'f> Writer<'s, 'f> {
                     number,
                 )?;
 
-                self.block(&mut out, 0)?;
+                self.block(&mut out, indent, 0)?;
                 out.write_str("</li>")?;
             }
 
-            self.block(&mut out, 0)?;
+            self.block(&mut out, indent, 0)?;
             out.write_str("</ol>")?;
-            self.block(&mut out, 0)?;
+            self.block(&mut out, indent, 0)?;
             out.write_str("</section>")?;
         }
 
-        if self.indent.is_some() {
+        if indent.is_some() {
             out.write_char('\n')?;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,8 @@ pub enum Event<'s> {
     ///             [(AttributeKind::Id, "b".into())].into_iter().collect(),
     ///         ),
     ///         Event::Str("word".into()),
-    ///         Event::End(Container::Span),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p id=\"a\"><span id=\"b\">word</span></p>\n";
@@ -141,7 +141,7 @@ pub enum Event<'s> {
     /// End of a container.
     ///
     /// Always paired with a matching [`Event::Start`].
-    End(Container<'s>),
+    End,
     /// A string object, text only.
     ///
     /// The strings from the parser will always be borrowed, but users may replace them with owned
@@ -158,7 +158,7 @@ pub enum Event<'s> {
     ///     &[
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("str".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>str</p>\n";
@@ -180,7 +180,7 @@ pub enum Event<'s> {
     ///         Event::Str("txt".into()),
     ///         Event::FootnoteReference("nb".into()),
     ///         Event::Str(".".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -211,7 +211,7 @@ pub enum Event<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("a ".into()),
     ///         Event::Symbol("sym".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>a :sym:</p>\n";
@@ -233,7 +233,7 @@ pub enum Event<'s> {
     ///         Event::LeftSingleQuote,
     ///         Event::Str("quote".into()),
     ///         Event::RightSingleQuote,
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>‘quote’</p>\n";
@@ -255,7 +255,7 @@ pub enum Event<'s> {
     ///         Event::RightSingleQuote,
     ///         Event::Str("Tis Socrates".into()),
     ///         Event::RightSingleQuote,
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>’Tis Socrates’</p>\n";
@@ -278,7 +278,7 @@ pub enum Event<'s> {
     ///         Event::Str("Hello,".into()),
     ///         Event::RightDoubleQuote,
     ///         Event::Str(" he said".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>“Hello,” he said</p>\n";
@@ -301,7 +301,7 @@ pub enum Event<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("yes".into()),
     ///         Event::Ellipsis,
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>yes…</p>\n";
@@ -323,7 +323,7 @@ pub enum Event<'s> {
     ///         Event::Str("57".into()),
     ///         Event::EnDash,
     ///         Event::Str("33".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>57–33</p>\n";
@@ -345,7 +345,7 @@ pub enum Event<'s> {
     ///         Event::Str("oxen".into()),
     ///         Event::EmDash,
     ///         Event::Str("and".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>oxen—and</p>\n";
@@ -368,7 +368,7 @@ pub enum Event<'s> {
     ///         Event::Escape,
     ///         Event::NonBreakingSpace,
     ///         Event::Str("break".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>no&nbsp;break</p>\n";
@@ -393,7 +393,7 @@ pub enum Event<'s> {
     ///         Event::Str("soft".into()),
     ///         Event::Softbreak,
     ///         Event::Str("break".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -422,7 +422,7 @@ pub enum Event<'s> {
     ///         Event::Escape,
     ///         Event::Hardbreak,
     ///         Event::Str("break".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -448,7 +448,7 @@ pub enum Event<'s> {
     ///         Event::Str("*a".into()),
     ///         Event::Escape,
     ///         Event::Str("*".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>*a*</p>\n";
@@ -472,11 +472,11 @@ pub enum Event<'s> {
     ///     &[
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("para0".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("para1".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -507,12 +507,12 @@ pub enum Event<'s> {
     ///     &[
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("para0".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::ThematicBreak(Attributes::new()),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("para1".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::ThematicBreak(
     ///             [(AttributeKind::Class, "c".into())]
@@ -560,7 +560,7 @@ pub enum Event<'s> {
     ///                 .into_iter()
     ///                 .collect(),
     ///         ),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::Attributes(
     ///             [(AttributeKind::Id, "c".into())]
@@ -606,8 +606,8 @@ pub enum Container<'s> {
     ///         Event::Str("a".into()),
     ///         Event::Softbreak,
     ///         Event::Str("b".into()),
-    ///         Event::End(Container::Paragraph),
-    ///         Event::End(Container::Blockquote),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -644,18 +644,15 @@ pub enum Container<'s> {
     ///         Event::Start(Container::ListItem, Attributes::new()),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("a".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///         Event::Blankline,
-    ///         Event::End(Container::ListItem),
+    ///         Event::End,
     ///         Event::Start(Container::ListItem, Attributes::new()),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("b".into()),
-    ///         Event::End(Container::Paragraph),
-    ///         Event::End(Container::ListItem),
-    ///         Event::End(Container::List {
-    ///             kind: ListKind::Unordered(ListBulletType::Dash),
-    ///             tight: false
-    ///         }),
+    ///         Event::End,
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -692,12 +689,9 @@ pub enum Container<'s> {
     ///         Event::Start(Container::ListItem, Attributes::new()),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("a".into()),
-    ///         Event::End(Container::Paragraph),
-    ///         Event::End(Container::ListItem),
-    ///         Event::End(Container::List {
-    ///             kind: ListKind::Unordered(ListBulletType::Dash),
-    ///             tight: true,
-    ///         }),
+    ///         Event::End,
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -734,12 +728,9 @@ pub enum Container<'s> {
     ///         ),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("a".into()),
-    ///         Event::End(Container::Paragraph),
-    ///         Event::End(Container::TaskListItem { checked: true }),
-    ///         Event::End(Container::List {
-    ///             kind: ListKind::Task(ListBulletType::Dash),
-    ///             tight: true,
-    ///         }),
+    ///         Event::End,
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -774,23 +765,23 @@ pub enum Container<'s> {
     ///         Event::Start(Container::DescriptionList, Attributes::new()),
     ///         Event::Start(Container::DescriptionTerm, Attributes::new()),
     ///         Event::Str("orange".into()),
-    ///         Event::End(Container::DescriptionTerm),
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::Start(Container::DescriptionDetails, Attributes::new()),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("citrus fruit".into()),
-    ///         Event::End(Container::Paragraph),
-    ///         Event::End(Container::DescriptionDetails),
+    ///         Event::End,
+    ///         Event::End,
     ///         Event::Start(Container::DescriptionTerm, Attributes::new()),
     ///         Event::Str("apple".into()),
-    ///         Event::End(Container::DescriptionTerm),
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::Start(Container::DescriptionDetails, Attributes::new()),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("malus fruit".into()),
-    ///         Event::End(Container::Paragraph),
-    ///         Event::End(Container::DescriptionDetails),
-    ///         Event::End(Container::DescriptionList),
+    ///         Event::End,
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -828,7 +819,7 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("txt".into()),
     ///         Event::FootnoteReference("nb".into()),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::Start(
     ///             Container::Footnote { label: "nb".into() },
@@ -836,8 +827,8 @@ pub enum Container<'s> {
     ///         ),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("actually..".into()),
-    ///         Event::End(Container::Paragraph),
-    ///         Event::End(Container::Footnote { label: "nb".into() }),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -882,10 +873,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("a".into()),
-    ///         Event::End(Container::TableCell {
-    ///             alignment: Alignment::Unspecified,
-    ///             head: true,
-    ///         }),
+    ///         Event::End,
     ///         Event::Start(
     ///             Container::TableCell {
     ///                 alignment: Alignment::Right,
@@ -894,11 +882,8 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("b".into()),
-    ///         Event::End(Container::TableCell {
-    ///             alignment: Alignment::Right,
-    ///             head: true,
-    ///         }),
-    ///         Event::End(Container::TableRow { head: true } ),
+    ///         Event::End,
+    ///         Event::End,
     ///         Event::Start(
     ///             Container::TableRow { head: false },
     ///             Attributes::new(),
@@ -911,10 +896,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("1".into()),
-    ///         Event::End(Container::TableCell {
-    ///             alignment: Alignment::Unspecified,
-    ///             head: false,
-    ///         }),
+    ///         Event::End,
     ///         Event::Start(
     ///             Container::TableCell {
     ///                 alignment: Alignment::Right,
@@ -923,12 +905,9 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("2".into()),
-    ///         Event::End(Container::TableCell {
-    ///             alignment: Alignment::Right,
-    ///             head: false,
-    ///         }),
-    ///         Event::End(Container::TableRow { head: false } ),
-    ///         Event::End(Container::Table),
+    ///         Event::End,
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -976,11 +955,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("outer".into()),
-    ///         Event::End(Container::Heading {
-    ///             level: 1,
-    ///             has_section: true,
-    ///             id: "outer".into(),
-    ///         }),
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::Start(
     ///             Container::Section { id: "inner".into() },
@@ -995,13 +970,9 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("inner".into()),
-    ///         Event::End(Container::Heading {
-    ///             level: 2,
-    ///             has_section: true,
-    ///             id: "inner".into(),
-    ///         }),
-    ///         Event::End(Container::Section { id: "inner".into() }),
-    ///         Event::End(Container::Section { id: "outer".into() }),
+    ///         Event::End,
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1036,8 +1007,8 @@ pub enum Container<'s> {
     ///         ),
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Str("this is a note".into()),
-    ///         Event::End(Container::Paragraph),
-    ///         Event::End(Container::Div { class: "note".into() }),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1074,12 +1045,8 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("heading".into()),
-    ///         Event::End(Container::Heading {
-    ///             level: 1,
-    ///             has_section: true,
-    ///             id: "heading".into(),
-    ///         }),
-    ///         Event::End(Container::Section { id: "heading".into() }),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1113,7 +1080,7 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Table, Attributes::new()),
     ///         Event::Start(Container::Caption, Attributes::new()),
     ///         Event::Str("caption".into()),
-    ///         Event::End(Container::Caption),
+    ///         Event::End,
     ///         Event::Start(
     ///             Container::TableRow { head: false },
     ///             Attributes::new(),
@@ -1126,12 +1093,9 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("a".into()),
-    ///         Event::End(Container::TableCell {
-    ///             alignment: Alignment::Unspecified,
-    ///             head: false,
-    ///         }),
-    ///         Event::End(Container::TableRow { head: false } ),
-    ///         Event::End(Container::Table),
+    ///         Event::End,
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1163,7 +1127,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("url".into()),
-    ///         Event::End(Container::LinkDefinition { label: "label".into() }),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "\n";
@@ -1190,7 +1154,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("<tag>x</tag>".into()),
-    ///         Event::End(Container::RawBlock { format: "html".into() }),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<tag>x</tag>\n";
@@ -1217,7 +1181,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("<tag>x</tag>\n".into()),
-    ///         Event::End(Container::CodeBlock { language: "html".into() }),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1249,15 +1213,15 @@ pub enum Container<'s> {
     ///             [(AttributeKind::Id, "a".into())].into_iter().collect(),
     ///         ),
     ///         Event::Str("word".into()),
-    ///         Event::End(Container::Span),
+    ///         Event::End,
     ///         Event::Softbreak,
     ///         Event::Start(
     ///             Container::Span,
     ///             [(AttributeKind::Id, "b".into())].into_iter().collect(),
     ///         ),
     ///         Event::Str("two words".into()),
-    ///         Event::End(Container::Span),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1292,10 +1256,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("https://example.com".into()),
-    ///         Event::End(Container::Link(
-    ///             "https://example.com".into(),
-    ///             LinkType::AutoLink,
-    ///         )),
+    ///         Event::End,
     ///         Event::Softbreak,
     ///         Event::Start(
     ///             Container::Link(
@@ -1305,11 +1266,8 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("me@example.com".into()),
-    ///         Event::End(Container::Link(
-    ///             "me@example.com".into(),
-    ///             LinkType::Email,
-    ///         )),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1337,11 +1295,8 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("anchor".into()),
-    ///         Event::End(
-    ///             Container::Link("url".into(),
-    ///             LinkType::Span(SpanLinkType::Inline)),
-    ///         ),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><a href=\"url\">anchor</a></p>\n";
@@ -1372,10 +1327,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("a".into()),
-    ///         Event::End(
-    ///             Container::Link("url".into(),
-    ///             LinkType::Span(SpanLinkType::Reference)),
-    ///         ),
+    ///         Event::End,
     ///         Event::Softbreak,
     ///         Event::Start(
     ///             Container::Link(
@@ -1385,18 +1337,15 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("b".into()),
-    ///         Event::End(
-    ///             Container::Link("non-existent".into(),
-    ///             LinkType::Span(SpanLinkType::Unresolved)),
-    ///         ),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///         Event::Blankline,
     ///         Event::Start(
     ///             Container::LinkDefinition { label: "label".into() },
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("url".into()),
-    ///         Event::End(Container::LinkDefinition { label: "label".into() }),
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1425,10 +1374,8 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str("alt text".into()),
-    ///         Event::End(
-    ///             Container::Image("img.png".into(), SpanLinkType::Inline),
-    ///         ),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><img alt=\"alt text\" src=\"img.png\"></p>\n";
@@ -1450,8 +1397,8 @@ pub enum Container<'s> {
     ///         Event::Str("inline ".into()),
     ///         Event::Start(Container::Verbatim, Attributes::new()),
     ///         Event::Str("verbatim".into()),
-    ///         Event::End(Container::Verbatim),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p>inline <code>verbatim</code></p>\n";
@@ -1479,7 +1426,7 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str(r"a\cdot{}b".into()),
-    ///         Event::End(Container::Math { display: false }),
+    ///         Event::End,
     ///         Event::Str(" or".into()),
     ///         Event::Softbreak,
     ///         Event::Str("display ".into()),
@@ -1488,8 +1435,8 @@ pub enum Container<'s> {
     ///             Attributes::new(),
     ///         ),
     ///         Event::Str(r"\frac{a}{b}".into()),
-    ///         Event::End(Container::Math { display: true }),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = concat!(
@@ -1515,8 +1462,8 @@ pub enum Container<'s> {
     ///             Container::RawInline { format: "html".into() }, Attributes::new(),
     ///         ),
     ///         Event::Str("<tag>a</tag>".into()),
-    ///         Event::End(Container::RawInline { format: "html".into() }),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><tag>a</tag></p>\n";
@@ -1537,8 +1484,8 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Start(Container::Subscript, Attributes::new()),
     ///         Event::Str("SUB".into()),
-    ///         Event::End(Container::Subscript),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><sub>SUB</sub></p>\n";
@@ -1559,8 +1506,8 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Start(Container::Superscript, Attributes::new()),
     ///         Event::Str("SUP".into()),
-    ///         Event::End(Container::Superscript),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><sup>SUP</sup></p>\n";
@@ -1581,8 +1528,8 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Start(Container::Insert, Attributes::new()),
     ///         Event::Str("INS".into()),
-    ///         Event::End(Container::Insert),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><ins>INS</ins></p>\n";
@@ -1603,8 +1550,8 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Start(Container::Delete, Attributes::new()),
     ///         Event::Str("DEL".into()),
-    ///         Event::End(Container::Delete),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><del>DEL</del></p>\n";
@@ -1625,8 +1572,8 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Start(Container::Strong, Attributes::new()),
     ///         Event::Str("STRONG".into()),
-    ///         Event::End(Container::Strong),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><strong>STRONG</strong></p>\n";
@@ -1647,8 +1594,8 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Start(Container::Emphasis, Attributes::new()),
     ///         Event::Str("EM".into()),
-    ///         Event::End(Container::Emphasis),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><em>EM</em></p>\n";
@@ -1669,8 +1616,8 @@ pub enum Container<'s> {
     ///         Event::Start(Container::Paragraph, Attributes::new()),
     ///         Event::Start(Container::Mark, Attributes::new()),
     ///         Event::Str("MARK".into()),
-    ///         Event::End(Container::Mark),
-    ///         Event::End(Container::Paragraph),
+    ///         Event::End,
+    ///         Event::End,
     ///     ],
     /// );
     /// let html = "<p><mark>MARK</mark></p>\n";
@@ -2246,13 +2193,13 @@ impl<'s> Parser<'s> {
     ///         ("", Start(Paragraph, ..)),
     ///         ("_", Start(Emphasis, ..)),
     ///         ("hello", Str(..)),
-    ///         ("_", End(Emphasis)),
+    ///         ("_", End),
     ///         (" ", Str(..)),
     ///         ("[", Start(Link { .. }, ..)),
     ///         ("text", Str(..)),
-    ///         ("](url)", End(Link { .. })),
-    ///         ("", End(Paragraph)),
-    ///         ("", End(Blockquote)),
+    ///         ("](url)", End),
+    ///         ("", End),
+    ///         ("", End),
     ///     ],
     /// ));
     /// ```
@@ -2279,10 +2226,10 @@ impl<'s> Parser<'s> {
     ///         ("", Start(Paragraph, ..)),
     ///         ("[", Start(Span, ..)),
     ///         ("Hello", Str(..)),
-    ///         ("]{lang=en}", End(Span)),
+    ///         ("]{lang=en}", End),
     ///         (" world!", Str(..)),
-    ///         ("", End(Paragraph)),
-    ///         ("", End(Blockquote)),
+    ///         ("", End),
+    ///         ("", End),
     ///     ],
     /// ));
     /// ```
@@ -2309,9 +2256,9 @@ impl<'s> Parser<'s> {
     ///         ("", Start(Paragraph, ..)),
     ///         ("[", Start(Link { .. }, ..)),
     ///         ("txt", Str(..)),
-    ///         ("](multi\n> line)", End(Link { .. })),
-    ///         ("", End(Paragraph)),
-    ///         ("", End(Blockquote)),
+    ///         ("](multi\n> line)", End),
+    ///         ("", End),
+    ///         ("", End),
     ///     ],
     /// ));
     /// ```
@@ -2397,7 +2344,7 @@ impl<'s> Parser<'s> {
                     if enter {
                         Event::Start(t, attributes.take())
                     } else {
-                        Event::End(t)
+                        Event::End
                     }
                 }
                 inline::EventKind::Atom(a) => match a {
@@ -2595,7 +2542,7 @@ impl<'s> Parser<'s> {
                         ev_span = sp;
                         Event::Attributes(attrs)
                     } else {
-                        Event::End(cont)
+                        Event::End
                     }
                 }
                 block::EventKind::Inline => {

--- a/tests/afl/src/lib.rs
+++ b/tests/afl/src/lib.rs
@@ -19,7 +19,7 @@ pub fn parse(data: &[u8]) {
                     matches!(
                         last.0,
                         jotdown::Event::Start(jotdown::Container::Caption, ..)
-                        | jotdown::Event::End(jotdown::Container::Caption)
+                        | jotdown::Event::End
                     )
                     && range.end <= last.1.start
                 ),
@@ -34,10 +34,6 @@ pub fn parse(data: &[u8]) {
             let _ = &s[range];
             match event {
                 jotdown::Event::Start(c, ..) => open.push(c.clone()),
-                jotdown::Event::End(c) => {
-                    // closes correct event
-                    assert_eq!(open.pop().unwrap(), c);
-                }
                 _ => {}
             }
         }

--- a/tests/afl/src/lib.rs
+++ b/tests/afl/src/lib.rs
@@ -1,9 +1,8 @@
-use jotdown::Render;
-
 use html5ever::tendril;
 use html5ever::tendril::TendrilSink;
 use html5ever::tokenizer;
 use html5ever::tree_builder;
+use jotdown::RenderExt;
 
 /// Perform sanity checks on events.
 pub fn parse(data: &[u8]) {
@@ -63,7 +62,8 @@ pub fn html(data: &[u8]) {
             let p = jotdown::Parser::new(s);
             let mut html = "<!DOCTYPE html>\n".to_string();
             jotdown::html::Renderer::default()
-                .push(p, &mut html)
+                .with_fmt_writer(&mut html)
+                .render_events(p)
                 .unwrap();
             validate_html(&html);
         }

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,0 +1,46 @@
+use jotdown::{Container, Event, Render, RenderExt as _};
+use std::borrow::Cow;
+
+struct RickrollRenderer<R>(R);
+
+impl<'s, R> Render<'s> for RickrollRenderer<R>
+where
+    R: Render<'s>,
+{
+    type Error = R::Error;
+
+    fn begin(&mut self) -> Result<(), Self::Error> {
+        self.0.begin()
+    }
+
+    fn emit(&mut self, event: Event<'s>) -> Result<(), Self::Error> {
+        match event {
+            Event::Start(Container::Link(_link, t), attrs) => self.0.emit(Event::Start(
+                Container::Link(
+                    Cow::Owned("https://www.youtube.com/watch?v=E4WlUXrJgy4".to_owned()),
+                    t,
+                ),
+                attrs,
+            )),
+            _ => self.0.emit(event),
+        }
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        self.0.finish()
+    }
+}
+
+#[test]
+fn rickroll_me() {
+    use jotdown::RenderOutputExt;
+    let src = "[interesting link](https://example.com)";
+    let out = RickrollRenderer(jotdown::html::Renderer::minified())
+        .render_into_document(src)
+        .unwrap();
+
+    assert_eq!(
+        r.0.into_inner(),
+        "<p><a href=\"https://www.youtube.com/watch?v=E4WlUXrJgy4\">interesting link</a></p>"
+    );
+}

--- a/tests/html-ref/lib.rs
+++ b/tests/html-ref/lib.rs
@@ -4,14 +4,9 @@ mod r#ref;
 #[macro_export]
 macro_rules! compare {
     ($src:expr, $expected:expr) => {
-        use jotdown::Render;
         let src = $src;
         let expected = std::fs::read_to_string($expected).expect("read failed");
-        let p = jotdown::Parser::new(src);
-        let mut actual = String::new();
-        jotdown::html::Renderer::default()
-            .push(p, &mut actual)
-            .unwrap();
+        let actual = jotdown::html::Renderer::default().render_to_string(src);
         assert_eq!(actual, expected, "\n{}", {
             use std::io::Write;
             let mut child = std::process::Command::new("diff")

--- a/tests/html-ut/lib.rs
+++ b/tests/html-ut/lib.rs
@@ -6,8 +6,7 @@ macro_rules! compare {
     ($src:expr, $expected:expr) => {
         let src = $src;
         let expected = $expected;
-        let p = jotdown::Parser::new(src);
-        let actual = jotdown::html::render_to_string(p);
+        let actual = jotdown::html::render_to_string(src);
         assert_eq!(
             actual.trim(),
             expected.trim(),

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -1,15 +1,14 @@
 use jotdown::html::Indentation;
-use jotdown::Render;
+use jotdown::RenderExt;
 
 macro_rules! test_html {
     ($src:expr, $expected:expr $(,$indent:expr)? $(,)?) => {
         #[allow(unused)]
         let mut renderer = jotdown::html::Renderer::minified();
         $(renderer = jotdown::html::Renderer::indented($indent);)?
-        let mut actual = String::new();
         renderer
-            .push(jotdown::Parser::new($src), &mut actual)
-            .unwrap();
+            .render_document($src).expect("Can't fail");
+        let actual = renderer.into_inner();
         assert_eq!(actual, $expected);
     };
     ($src:expr, $expected:expr, $(,)?) => {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,4 @@
 mod attr;
+mod filters;
 mod html;
 mod parse_events;

--- a/tests/parse_events.rs
+++ b/tests/parse_events.rs
@@ -88,15 +88,8 @@ fn heading() {
             ),
             "#",
         ),
-        (
-            End(Heading {
-                level: 1,
-                has_section: true,
-                id: "s-1".into(),
-            }),
-            "",
-        ),
-        (End(Section { id: "s-1".into() }), ""),
+        (End, "",),
+        (End, ""),
     );
     test_parse!(
         "# abc\ndef\n",
@@ -123,20 +116,8 @@ fn heading() {
         (Str("abc".into()), "abc"),
         (Softbreak, "\n"),
         (Str("def".into()), "def"),
-        (
-            End(Heading {
-                level: 1,
-                has_section: true,
-                id: "abc-def".into(),
-            }),
-            "",
-        ),
-        (
-            End(Section {
-                id: "abc-def".into(),
-            }),
-            "",
-        ),
+        (End, "",),
+        (End, "",),
     );
 }
 
@@ -161,15 +142,8 @@ fn heading_attr() {
             "#",
         ),
         (Str("abc".into()), "abc"),
-        (
-            End(Heading {
-                level: 1,
-                has_section: true,
-                id: "abc".into(),
-            }),
-            "",
-        ),
-        (End(Section { id: "abc".into() }), ""),
+        (End, "",),
+        (End, ""),
         (
             Start(
                 Section { id: "def".into() },
@@ -189,15 +163,8 @@ fn heading_attr() {
             "#",
         ),
         (Str("def".into()), "def"),
-        (
-            End(Heading {
-                level: 1,
-                has_section: true,
-                id: "def".into(),
-            }),
-            "",
-        ),
-        (End(Section { id: "def".into() }), ""),
+        (End, "",),
+        (End, ""),
     );
 }
 
@@ -222,15 +189,9 @@ fn heading_ref() {
             "[",
         ),
         (Str("link".into()), "link"),
-        (
-            End(Link(
-                "#Some-Section".into(),
-                LinkType::Span(SpanLinkType::Reference),
-            )),
-            "][Some Section]",
-        ),
+        (End, "][Some Section]",),
         (Str(" to another section.".into()), " to another section."),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -253,20 +214,8 @@ fn heading_ref() {
             "#",
         ),
         (Str("Some Section".into()), "Some Section"),
-        (
-            End(Heading {
-                level: 1,
-                has_section: true,
-                id: "Some-Section".into(),
-            }),
-            "",
-        ),
-        (
-            End(Section {
-                id: "Some-Section".into(),
-            }),
-            "",
-        ),
+        (End, "",),
+        (End, "",),
     );
     test_parse!(
         concat!(
@@ -286,10 +235,7 @@ fn heading_ref() {
             "[",
         ),
         (Str("a".into()), "a"),
-        (
-            End(Link("#a".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][]",
-        ),
+        (End, "][]",),
         (Softbreak, "\n"),
         (
             Start(
@@ -299,11 +245,8 @@ fn heading_ref() {
             "[",
         ),
         (Str("b".into()), "b"),
-        (
-            End(Link("#b".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][]",
-        ),
-        (End(Paragraph), ""),
+        (End, "][]",),
+        (End, ""),
         (Blankline, "\n"),
         (Start(Section { id: "b".into() }, Attributes::new()), ""),
         (
@@ -318,16 +261,9 @@ fn heading_ref() {
             "#",
         ),
         (Str("b".into()), "b"),
-        (
-            End(Heading {
-                level: 1,
-                has_section: true,
-                id: "b".into(),
-            }),
-            "",
-        ),
+        (End, "",),
         (Blankline, "\n"),
-        (End(Section { id: "b".into() }), ""),
+        (End, ""),
         (Start(Section { id: "a".into() }, Attributes::new()), ""),
         (
             Start(
@@ -341,15 +277,8 @@ fn heading_ref() {
             "#",
         ),
         (Str("a".into()), "a"),
-        (
-            End(Heading {
-                level: 1,
-                has_section: true,
-                id: "a".into(),
-            }),
-            "",
-        ),
-        (End(Section { id: "a".into() }), ""),
+        (End, "",),
+        (End, ""),
     );
 }
 
@@ -359,7 +288,7 @@ fn blockquote() {
         ">\n",
         (Start(Blockquote, Attributes::new()), ">"),
         (Blankline, "\n"),
-        (End(Blockquote), ""),
+        (End, ""),
     );
 }
 
@@ -369,23 +298,23 @@ fn para() {
         "para",
         (Start(Paragraph, Attributes::new()), ""),
         (Str("para".into()), "para"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         "pa     ra",
         (Start(Paragraph, Attributes::new()), ""),
         (Str("pa     ra".into()), "pa     ra"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         "para0\n\npara1",
         (Start(Paragraph, Attributes::new()), ""),
         (Str("para0".into()), "para0"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("para1".into()), "para1"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -396,8 +325,8 @@ fn verbatim() {
         (Start(Paragraph, Attributes::new()), ""),
         (Start(Verbatim, Attributes::new()), "`"),
         (Str("abc\ndef".into()), "abc\ndef"),
-        (End(Verbatim), ""),
-        (End(Paragraph), ""),
+        (End, ""),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -409,9 +338,9 @@ fn verbatim() {
         (Start(Verbatim, Attributes::new()), "`"),
         (Str("abc\n".into()), "abc\n"),
         (Str("def".into()), "def"),
-        (End(Verbatim), ""),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, ""),
+        (End, ""),
+        (End, ""),
     );
 }
 
@@ -430,13 +359,8 @@ fn raw_inline() {
             "``",
         ),
         (Str("raw\nraw".into()), "raw\nraw"),
-        (
-            End(RawInline {
-                format: "format".into()
-            }),
-            "``{=format}"
-        ),
-        (End(Paragraph), ""),
+        (End, "``{=format}"),
+        (End, ""),
     );
 }
 
@@ -454,12 +378,7 @@ fn raw_block() {
             "``` =html\n",
         ),
         (Str("<table>".into()), "<table>"),
-        (
-            End(RawBlock {
-                format: "html".into()
-            }),
-            "```"
-        ),
+        (End, "```"),
     );
 }
 
@@ -490,16 +409,11 @@ fn raw_block_whitespace() {
         ),
         (Str("<tag1>\n".into()), "<tag1>\n"),
         (Str("<tag2>".into()), "<tag2>"),
-        (
-            End(RawBlock {
-                format: "html".into()
-            }),
-            "```\n"
-        ),
+        (End, "```\n"),
         (Blankline, "\n"),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("paragraph".into()), "paragraph"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -512,12 +426,7 @@ fn raw_block_whitespace() {
         ),
         (Str("</tag2>\n".into()), "</tag2>\n"),
         (Str("</tag1>".into()), "</tag1>"),
-        (
-            End(RawBlock {
-                format: "html".into()
-            }),
-            "```\n"
-        ),
+        (End, "```\n"),
     );
 }
 
@@ -529,7 +438,7 @@ fn symbol() {
         (Str("abc ".into()), "abc "),
         (Symbol("+1".into()), ":+1:"),
         (Str(" def".into()), " def"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -546,11 +455,8 @@ fn link_inline() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("url".into(), LinkType::Span(SpanLinkType::Inline))),
-            "](url)",
-        ),
-        (End(Paragraph), ""),
+        (End, "](url)",),
+        (End, ""),
     );
 }
 
@@ -571,12 +477,9 @@ fn link_inline_multi_line() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("urlurl".into(), LinkType::Span(SpanLinkType::Inline))),
-            "](url\n> url)",
-        ),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, "](url\n> url)",),
+        (End, ""),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -594,12 +497,9 @@ fn link_inline_multi_line() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("abcdef".into(), LinkType::Span(SpanLinkType::Inline))),
-            "](a\n> bc\n> def)",
-        ),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, "](a\n> bc\n> def)",),
+        (End, ""),
+        (End, ""),
     );
 }
 
@@ -620,11 +520,8 @@ fn link_reference() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("url".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][tag]",
-        ),
-        (End(Paragraph), ""),
+        (End, "][tag]",),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -636,12 +533,7 @@ fn link_reference() {
             "[tag]:",
         ),
         (Str("url".into()), "url"),
-        (
-            End(LinkDefinition {
-                label: "tag".into()
-            }),
-            ""
-        ),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -658,8 +550,8 @@ fn link_reference() {
             "![",
         ),
         (Str("text".into()), "text"),
-        (End(Image("url".into(), SpanLinkType::Reference)), "][tag]"),
-        (End(Paragraph), ""),
+        (End, "][tag]"),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -671,12 +563,7 @@ fn link_reference() {
             "[tag]:",
         ),
         (Str("url".into()), "url"),
-        (
-            End(LinkDefinition {
-                label: "tag".into()
-            }),
-            ""
-        ),
+        (End, ""),
     );
 }
 
@@ -693,11 +580,8 @@ fn link_reference_unresolved() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("tag".into(), LinkType::Span(SpanLinkType::Unresolved))),
-            "][tag]",
-        ),
-        (End(Paragraph), ""),
+        (End, "][tag]",),
+        (End, ""),
     );
     test_parse!(
         "![text][tag]",
@@ -710,8 +594,8 @@ fn link_reference_unresolved() {
             "![",
         ),
         (Str("text".into()), "text"),
-        (End(Image("tag".into(), SpanLinkType::Unresolved)), "][tag]"),
-        (End(Paragraph), ""),
+        (End, "][tag]"),
+        (End, ""),
     );
 }
 
@@ -734,12 +618,9 @@ fn link_reference_multiline() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("url".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][a\n> b]",
-        ),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, "][a\n> b]",),
+        (End, ""),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -751,12 +632,7 @@ fn link_reference_multiline() {
             "[a b]:",
         ),
         (Str("url".into()), "url"),
-        (
-            End(LinkDefinition {
-                label: "a b".into()
-            }),
-            ""
-        ),
+        (End, ""),
     );
 }
 
@@ -783,10 +659,7 @@ fn link_reference_multiline_empty() {
         (Str("a".into()), "a"),
         (Softbreak, "\n"),
         (Str("b".into()), "b"),
-        (
-            End(Link("url".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][]",
-        ),
+        (End, "][]",),
         (Softbreak, "\n"),
         (
             Start(
@@ -799,12 +672,9 @@ fn link_reference_multiline_empty() {
         (Escape, "\\"),
         (Hardbreak, "\n"),
         (Str("b".into()), "b"),
-        (
-            End(Link("url".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][]",
-        ),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, "][]",),
+        (End, ""),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -816,12 +686,7 @@ fn link_reference_multiline_empty() {
             "[a b]:",
         ),
         (Str("url".into()), "url"),
-        (
-            End(LinkDefinition {
-                label: "a b".into()
-            }),
-            ""
-        ),
+        (End, ""),
     );
 }
 
@@ -843,11 +708,8 @@ fn link_definition_multiline() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("url".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][tag]",
-        ),
-        (End(Paragraph), ""),
+        (End, "][tag]",),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -860,12 +722,7 @@ fn link_definition_multiline() {
         ),
         (Str("u".into()), "u"),
         (Str("rl".into()), "rl"),
-        (
-            End(LinkDefinition {
-                label: "tag".into()
-            }),
-            ""
-        ),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -884,14 +741,8 @@ fn link_definition_multiline() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link(
-                "urlcont".into(),
-                LinkType::Span(SpanLinkType::Reference),
-            )),
-            "][tag]",
-        ),
-        (End(Paragraph), ""),
+        (End, "][tag]",),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -904,12 +755,7 @@ fn link_definition_multiline() {
         ),
         (Str("url".into()), "url"),
         (Str("cont".into()), "cont"),
-        (
-            End(LinkDefinition {
-                label: "tag".into()
-            }),
-            ""
-        ),
+        (End, ""),
     );
 }
 
@@ -935,11 +781,8 @@ fn link_reference_attrs() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("url".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][tag]{b=c}",
-        ),
-        (End(Paragraph), ""),
+        (End, "][tag]{b=c}",),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -951,15 +794,10 @@ fn link_reference_attrs() {
             "{a=b}\n[tag]:",
         ),
         (Str("url".into()), "url"),
-        (
-            End(LinkDefinition {
-                label: "tag".into()
-            }),
-            ""
-        ),
+        (End, ""),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("para".into()), "para"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -985,11 +823,8 @@ fn link_reference_attrs_class() {
             "[",
         ),
         (Str("text".into()), "text"),
-        (
-            End(Link("url".into(), LinkType::Span(SpanLinkType::Reference))),
-            "][tag]{.link}",
-        ),
-        (End(Paragraph), ""),
+        (End, "][tag]{.link}",),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(
@@ -1001,15 +836,10 @@ fn link_reference_attrs_class() {
             "{.def}\n[tag]:",
         ),
         (Str("url".into()), "url"),
-        (
-            End(LinkDefinition {
-                label: "tag".into()
-            }),
-            ""
-        ),
+        (End, ""),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("para".into()), "para"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -1026,8 +856,8 @@ fn autolink() {
             "<",
         ),
         (Str("proto:url".into()), "proto:url"),
-        (End(Link("proto:url".into(), LinkType::AutoLink)), ">"),
-        (End(Paragraph), ""),
+        (End, ">"),
+        (End, ""),
     );
 }
 
@@ -1044,8 +874,8 @@ fn email() {
             "<",
         ),
         (Str("name@domain".into()), "name@domain"),
-        (End(Link("name@domain".into(), LinkType::Email)), ">"),
-        (End(Paragraph), ""),
+        (End, ">"),
+        (End, ""),
     );
 }
 
@@ -1057,7 +887,7 @@ fn footnote_references() {
         (FootnoteReference("a".into()), "[^a]"),
         (FootnoteReference("b".into()), "[^b]"),
         (FootnoteReference("c".into()), "[^c]"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -1067,7 +897,7 @@ fn footnote() {
         "[^a]\n\n[^a]: a\n",
         (Start(Paragraph, Attributes::new()), ""),
         (FootnoteReference("a".into()), "[^a]"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(Footnote { label: "a".into() }, Attributes::new()),
@@ -1075,8 +905,8 @@ fn footnote() {
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("a".into()), "a"),
-        (End(Paragraph), ""),
-        (End(Footnote { label: "a".into() }), ""),
+        (End, ""),
+        (End, ""),
     );
 }
 
@@ -1092,7 +922,7 @@ fn footnote_multiblock() {
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (FootnoteReference("a".into()), "[^a]"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(Footnote { label: "a".into() }, Attributes::new()),
@@ -1100,12 +930,12 @@ fn footnote_multiblock() {
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("abc".into()), "abc"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("def".into()), "def"),
-        (End(Paragraph), ""),
-        (End(Footnote { label: "a".into() }), ""),
+        (End, ""),
+        (End, ""),
     );
 }
 
@@ -1122,7 +952,7 @@ fn footnote_post() {
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (FootnoteReference("a".into()), "[^a]"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(Footnote { label: "a".into() }, Attributes::new()),
@@ -1132,12 +962,12 @@ fn footnote_post() {
         (Str("note".into()), "note"),
         (Softbreak, "\n"),
         (Str("cont".into()), "cont"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
-        (End(Footnote { label: "a".into() }), ""),
+        (End, ""),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("para".into()), "para"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -1148,7 +978,7 @@ fn footnote_post() {
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (FootnoteReference("a".into()), "[^a]"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (
             Start(Footnote { label: "a".into() }, Attributes::new()),
@@ -1156,10 +986,10 @@ fn footnote_post() {
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("note".into()), "note"),
-        (End(Paragraph), ""),
-        (End(Footnote { label: "a".into() }), ""),
+        (End, ""),
+        (End, ""),
         (Start(Div { class: "".into() }, Attributes::new()), ":::\n"),
-        (End(Div { class: "".into() }), ""),
+        (End, ""),
     );
 }
 
@@ -1172,7 +1002,7 @@ fn attr_block() {
             "{.some_class}\n",
         ),
         (Str("para".into()), "para"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -1188,7 +1018,7 @@ fn attr_block() {
             "{.a}\n{#b}\n",
         ),
         (Str("para".into()), "para"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -1202,7 +1032,7 @@ fn attr_block_dangling() {
         "para\n\n{.a}",
         (Start(Paragraph, Attributes::new()), ""),
         (Str("para".into()), "para"),
-        (End(Paragraph), ""),
+        (End, ""),
         (Blankline, "\n"),
         (Attributes(attrs![(AttributeKind::Class, "a")]), "{.a}"),
     );
@@ -1239,20 +1069,13 @@ fn attr_block_dangling_end_of_block() {
             "#"
         ),
         (Str("h".into()), "h"),
-        (
-            End(Heading {
-                level: 1,
-                has_section: true,
-                id: "h".into(),
-            }),
-            ""
-        ),
+        (End, ""),
         (Blankline, "\n"),
         (
             Attributes(attrs![(AttributeKind::Comment, "cmt")]),
             "{%cmt}",
         ),
-        (End(Section { id: "h".into() }), ""),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -1265,7 +1088,7 @@ fn attr_block_dangling_end_of_block() {
             Attributes(attrs![(AttributeKind::Comment, "cmt")]),
             "{%cmt}\n"
         ),
-        (End(Div { class: "".into() }), ":::\n"),
+        (End, ":::\n"),
     );
 }
 
@@ -1282,7 +1105,7 @@ fn attr_block_blankline() {
             "{.c}\n",
         ),
         (Str("para".into()), "para"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -1294,8 +1117,8 @@ fn attr_inline() {
         (Str("abc ".into()), "abc "),
         (Start(Emphasis, attrs![(AttributeKind::Class, "ghi")],), "_"),
         (Str("def".into()), "def"),
-        (End(Emphasis), "_{.ghi}"),
-        (End(Paragraph), ""),
+        (End, "_{.ghi}"),
+        (End, ""),
     );
 }
 
@@ -1316,8 +1139,8 @@ fn attr_inline_consecutive() {
             "_",
         ),
         (Str("abc def".into()), "abc def"),
-        (End(Emphasis), "_{.a}{.b #i}"),
-        (End(Paragraph), ""),
+        (End, "_{.a}{.b #i}"),
+        (End, ""),
     );
     test_parse!(
         "_abc def_{.a}{%%}{.b #i}",
@@ -1335,8 +1158,8 @@ fn attr_inline_consecutive() {
             "_",
         ),
         (Str("abc def".into()), "abc def"),
-        (End(Emphasis), "_{.a}{%%}{.b #i}"),
-        (End(Paragraph), ""),
+        (End, "_{.a}{%%}{.b #i}"),
+        (End, ""),
     );
 }
 
@@ -1357,9 +1180,9 @@ fn attr_inline_consecutive_invalid() {
             "_",
         ),
         (Str("abc def".into()), "abc def"),
-        (End(Emphasis), "_{.a}{.b #i}"),
+        (End, "_{.a}{.b #i}"),
         (Str("{.c invalid}".into()), "{.c invalid}"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         "_abc def_{.a}{.b #i}{%%}{.c invalid}",
@@ -1377,9 +1200,9 @@ fn attr_inline_consecutive_invalid() {
             "_",
         ),
         (Str("abc def".into()), "abc def"),
-        (End(Emphasis), "_{.a}{.b #i}{%%}"),
+        (End, "_{.a}{.b #i}{%%}"),
         (Str("{.c invalid}".into()), "{.c invalid}"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         concat!("_abc def_{.a}{.b #i}{%%}{.c\n", "invalid}\n"),
@@ -1397,11 +1220,11 @@ fn attr_inline_consecutive_invalid() {
             "_",
         ),
         (Str("abc def".into()), "abc def"),
-        (End(Emphasis), "_{.a}{.b #i}{%%}"),
+        (End, "_{.a}{.b #i}{%%}"),
         (Str("{.c".into()), "{.c"),
         (Softbreak, "\n"),
         (Str("invalid}".into()), "invalid}"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -1425,9 +1248,9 @@ fn attr_inline_multiline() {
             "_",
         ),
         (Str("abc".into()), "abc"),
-        (End(Emphasis), "_{a=b\n> c=d}"),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, "_{a=b\n> c=d}"),
+        (End, ""),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -1448,9 +1271,9 @@ fn attr_inline_multiline() {
             "",
         ),
         (Str("a".into()), "a"),
-        (End(Span), "{\n> %%\n> a=a}"),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, "{\n> %%\n> a=a}"),
+        (End, ""),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -1468,9 +1291,9 @@ fn attr_inline_multiline() {
             "",
         ),
         (Str("a".into()), "a"),
-        (End(Span), "{a=\"a\n> b\n> c\"}"),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, "{a=\"a\n> b\n> c\"}"),
+        (End, ""),
+        (End, ""),
     );
     test_parse!(
         concat!(
@@ -1484,9 +1307,9 @@ fn attr_inline_multiline() {
             "",
         ),
         (Str("a".into()), "a"),
-        (End(Span), "{a=\"\n> b\"}"),
-        (End(Paragraph), ""),
-        (End(Blockquote), ""),
+        (End, "{a=\"\n> b\"}"),
+        (End, ""),
+        (End, ""),
     );
 }
 
@@ -1501,8 +1324,8 @@ fn attr_inline_multiline_comment() {
         (Start(Paragraph, Attributes::new()), ""),
         (Start(Span, attrs![(AttributeKind::Comment, "a\nb\nc")]), "",),
         (Str("a".into()), "a"),
-        (End(Span), "{%a\nb\nc%}"),
-        (End(Paragraph), ""),
+        (End, "{%a\nb\nc%}"),
+        (End, ""),
     );
 }
 
@@ -1517,7 +1340,7 @@ fn attr_inline_multiline_unclosed() {
         (Str("a{".into()), "a{"),
         (Softbreak, "\n"),
         (Str("b".into()), "b"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -1535,7 +1358,7 @@ fn attr_inline_multiline_invalid() {
         (Str("b".into()), "b"),
         (Softbreak, "\n"),
         (Str("}".into()), "}"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -1547,7 +1370,7 @@ fn attr_inline_dangling() {
         (Str("*a".into()), "*a"),
         (Softbreak, "\n"),
         (Attributes(attrs![(AttributeKind::Comment, "")]), "{%}"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         "a {.b} c",
@@ -1555,7 +1378,7 @@ fn attr_inline_dangling() {
         (Str("a ".into()), "a "),
         (Attributes(attrs![(AttributeKind::Class, "b")]), "{.b}"),
         (Str(" c".into()), " c"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         "a {%cmt} c",
@@ -1566,7 +1389,7 @@ fn attr_inline_dangling() {
             "{%cmt}",
         ),
         (Str(" c".into()), " c"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         "a {%cmt}",
@@ -1576,7 +1399,7 @@ fn attr_inline_dangling() {
             Attributes(attrs![(AttributeKind::Comment, "cmt")]),
             "{%cmt}",
         ),
-        (End(Paragraph), ""),
+        (End, ""),
     );
     test_parse!(
         "{%cmt} a",
@@ -1586,7 +1409,7 @@ fn attr_inline_dangling() {
             "{%cmt}",
         ),
         (Str(" a".into()), " a"),
-        (End(Paragraph), ""),
+        (End, ""),
     );
 }
 
@@ -1607,15 +1430,9 @@ fn list_item_unordered() {
         (Start(ListItem, Attributes::new()), "-"),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("abc".into()), "abc"),
-        (End(Paragraph), ""),
-        (End(ListItem), ""),
-        (
-            End(List {
-                kind: ListKind::Unordered(Dash),
-                tight: true,
-            }),
-            "",
-        ),
+        (End, ""),
+        (End, ""),
+        (End, "",),
     );
 }
 
@@ -1640,19 +1457,9 @@ fn list_item_ordered_decimal() {
         (Start(ListItem, Attributes::new()), "123."),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("abc".into()), "abc"),
-        (End(Paragraph), ""),
-        (End(ListItem), ""),
-        (
-            End(List {
-                kind: ListKind::Ordered {
-                    numbering: Decimal,
-                    style: Period,
-                    start: 123,
-                },
-                tight: true,
-            }),
-            "",
-        ),
+        (End, ""),
+        (End, ""),
+        (End, "",),
     );
 }
 
@@ -1680,30 +1487,24 @@ fn list_task() {
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("a".into()), "a"),
-        (End(Paragraph), ""),
-        (End(TaskListItem { checked: false }), ""),
+        (End, ""),
+        (End, ""),
         (
             Start(TaskListItem { checked: true }, Attributes::new()),
             "- [x]",
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("b".into()), "b"),
-        (End(Paragraph), ""),
-        (End(TaskListItem { checked: true }), ""),
+        (End, ""),
+        (End, ""),
         (
             Start(TaskListItem { checked: true }, Attributes::new()),
             "- [X]",
         ),
         (Start(Paragraph, Attributes::new()), ""),
         (Str("c".into()), "c"),
-        (End(Paragraph), ""),
-        (End(TaskListItem { checked: true }), ""),
-        (
-            End(List {
-                kind: ListKind::Task(Dash),
-                tight: true,
-            }),
-            "",
-        ),
+        (End, ""),
+        (End, ""),
+        (End, "",),
     );
 }


### PR DESCRIPTION
This is on top of existing PRs.


Redundant data makes it harder for filtering/modifying renderers
to do their job, while it is quite simple for html (or any other)
actually rendering renderer to keep track of current container
nesting.